### PR TITLE
Update AWSEM to stable_23Jun2022 LAMMPS

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1,0 +1,2903 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "atom.h"
+#include "atom_vec.h"
+#include "style_atom.h"  // IWYU pragma: keep
+
+#include "comm.h"
+#include "compute.h"
+#include "domain.h"
+#include "error.h"
+#include "fix.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "math_const.h"
+#include "memory.h"
+#include "modify.h"
+#include "molecule.h"
+#include "neighbor.h"
+#include "tokenizer.h"
+#include "update.h"
+#include "variable.h"
+
+#include "library.h"
+
+#include <algorithm>
+#include <cstring>
+
+#ifdef LMP_GPU
+#include "fix_gpu.h"
+#include <cmath>
+#endif
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+#define DELTA 1
+#define EPSILON 1.0e-6
+
+/* ----------------------------------------------------------------------
+   one instance per AtomVec style in style_atom.h
+------------------------------------------------------------------------- */
+
+template <typename T> static AtomVec *avec_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+/** \class LAMMPS_NS::Atom
+ *  \brief Class to provide access to atom data
+
+\verbatim embed:rst
+The Atom class provides access to atom style related global settings and
+per-atom data that is stored with atoms and migrates with them from
+sub-domain to sub-domain as atoms move around.  This includes topology
+data, which is stored with either one specific atom or all atoms involved
+depending on the settings of the :doc:`newton command <newton>`.
+
+The actual per-atom data is allocated and managed by one of the various
+classes derived from the AtomVec class as determined by
+the :doc:`atom_style command <atom_style>`.  The pointers in the Atom class
+are updated by the AtomVec class as needed.
+\endverbatim
+ */
+
+/** Atom class constructor
+ *
+ * This resets and initialized all kinds of settings,
+ * parameters, and pointer variables for per-atom arrays.
+ * This also initializes the factory for creating
+ * instances of classes derived from the AtomVec base
+ * class, which correspond to the selected atom style.
+ *
+ * \param  lmp  pointer to the base LAMMPS class */
+
+Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
+{
+  natoms = 0;
+  nlocal = nghost = nmax = 0;
+  ntypes = 0;
+  nellipsoids = nlines = ntris = nbodies = 0;
+  nbondtypes = nangletypes = ndihedraltypes = nimpropertypes = 0;
+  nbonds = nangles = ndihedrals = nimpropers = 0;
+
+  firstgroupname = nullptr;
+  sortfreq = 1000;
+  nextsort = 0;
+  userbinsize = 0.0;
+  maxbin = maxnext = 0;
+  binhead = nullptr;
+  next = permute = nullptr;
+
+  // --------------------------------------------------------------------
+  // 1st customization section: customize by adding new per-atom variables
+
+  tag = nullptr;
+  type = mask = nullptr;
+  image = nullptr;
+  x = v = f = nullptr;
+
+  // charged and dipolar particles
+
+  q = nullptr;
+  mu = nullptr;
+
+  // finite-size particles
+
+  omega = angmom = torque = nullptr;
+  radius = rmass = nullptr;
+  ellipsoid = line = tri = body = nullptr;
+  quat = nullptr;
+
+  // molecular systems
+
+  molecule = nullptr;
+  molindex = molatom = nullptr;
+
+  bond_per_atom =  extra_bond_per_atom = 0;
+  num_bond = nullptr;
+  bond_type = nullptr;
+  bond_atom = nullptr;
+
+  angle_per_atom = extra_angle_per_atom = 0;
+  num_angle = nullptr;
+  angle_type = nullptr;
+  angle_atom1 = angle_atom2 = angle_atom3 = nullptr;
+
+  dihedral_per_atom = extra_dihedral_per_atom = 0;
+  num_dihedral = nullptr;
+  dihedral_type = nullptr;
+  dihedral_atom1 = dihedral_atom2 = dihedral_atom3 = dihedral_atom4 = nullptr;
+
+  improper_per_atom = extra_improper_per_atom = 0;
+  num_improper = nullptr;
+  improper_type = nullptr;
+  improper_atom1 = improper_atom2 = improper_atom3 = improper_atom4 = nullptr;
+
+  maxspecial = 1;
+  nspecial = nullptr;
+  special = nullptr;
+
+  // PERI package
+
+  vfrac = s0 = nullptr;
+  x0 = nullptr;
+
+  // SPIN package
+
+  sp = fm = fm_long = nullptr;
+
+  // EFF and AWPMD packages
+
+  spin = nullptr;
+  eradius = ervel = erforce = nullptr;
+  ervelforce = nullptr;
+  cs = csforce = vforce = nullptr;
+  etag = nullptr;
+
+  // CG-DNA package
+
+  id5p = nullptr;
+
+  // DPD-REACT package
+
+  uCond = uMech = uChem = uCG = uCGnew = nullptr;
+  duChem = dpdTheta = nullptr;
+
+  // MESO package
+
+  cc = cc_flux = nullptr;
+  edpd_temp = edpd_flux = edpd_cv = nullptr;
+
+  // MESONT package
+
+  length = nullptr;
+  buckling = nullptr;
+  bond_nt = nullptr;
+
+  // MACHDYN package
+
+  contact_radius = nullptr;
+  smd_data_9 = nullptr;
+  smd_stress = nullptr;
+  eff_plastic_strain = nullptr;
+  eff_plastic_strain_rate = nullptr;
+  damage = nullptr;
+
+  // SPH package
+
+  rho = drho = esph = desph = cv = nullptr;
+  vest = nullptr;
+
+  // DIELECTRIC package
+
+  area = ed = em = epsilon = curvature = q_unscaled = nullptr;
+
+  // AWSEM-MD package
+
+  residue = nullptr;
+
+  // end of customization section
+  // --------------------------------------------------------------------
+
+  // user-defined molecules
+
+  nmolecule = 0;
+  molecules = nullptr;
+
+  // custom atom arrays
+
+  nivector = ndvector = niarray = ndarray = 0;
+  ivector = nullptr;
+  dvector = nullptr;
+  iarray = nullptr;
+  darray = nullptr;
+  icols = dcols = nullptr;
+  ivname = dvname = ianame = daname = nullptr;
+
+  // initialize atom style and array existence flags
+
+  set_atomflag_defaults();
+
+  // initialize peratom data structure
+
+  peratom_create();
+
+  // ntype-length arrays
+
+  mass = nullptr;
+  mass_setflag = nullptr;
+
+  // callback lists & extra restart info
+
+  nextra_grow = nextra_restart = nextra_border = 0;
+  extra_grow = extra_restart = extra_border = nullptr;
+  nextra_grow_max = nextra_restart_max = nextra_border_max = 0;
+  nextra_store = 0;
+  extra = nullptr;
+
+  // default atom ID and mapping values
+
+  tag_enable = 1;
+  map_style = map_user = MAP_NONE;
+  map_tag_max = -1;
+  map_maxarray = map_nhash = map_nbucket = -1;
+
+  max_same = 0;
+  sametag = nullptr;
+  map_array = nullptr;
+  map_bucket = nullptr;
+  map_hash = nullptr;
+
+  unique_tags = nullptr;
+  reset_image_flag[0] = reset_image_flag[1] = reset_image_flag[2] = false;
+
+  atom_style = nullptr;
+  avec = nullptr;
+
+  avec_map = new AtomVecCreatorMap();
+
+#define ATOM_CLASS
+#define AtomStyle(key,Class) \
+  (*avec_map)[#key] = &avec_creator<Class>;
+#include "style_atom.h"  // IWYU pragma: keep
+#undef AtomStyle
+#undef ATOM_CLASS
+}
+
+/* ---------------------------------------------------------------------- */
+
+Atom::~Atom()
+{
+  delete[] atom_style;
+  delete avec;
+  delete avec_map;
+
+  delete[] firstgroupname;
+  memory->destroy(binhead);
+  memory->destroy(next);
+  memory->destroy(permute);
+
+  memory->destroy(tag);
+  memory->destroy(type);
+  memory->destroy(mask);
+  memory->destroy(image);
+  memory->destroy(x);
+  memory->destroy(v);
+  memory->destroy(f);
+
+  // delete custom atom arrays
+
+  for (int i = 0; i < nivector; i++) {
+    delete[] ivname[i];
+    memory->destroy(ivector[i]);
+  }
+  for (int i = 0; i < ndvector; i++) {
+    delete[] dvname[i];
+    if (dvector) // (needed for Kokkos)
+      memory->destroy(dvector[i]);
+  }
+  for (int i = 0; i < niarray; i++) {
+    delete[] ianame[i];
+    memory->destroy(iarray[i]);
+  }
+  for (int i = 0; i < ndarray; i++) {
+    delete[] daname[i];
+    memory->destroy(darray[i]);
+  }
+
+  memory->sfree(ivname);
+  memory->sfree(dvname);
+  memory->sfree(ianame);
+  memory->sfree(daname);
+  memory->sfree(ivector);
+  memory->sfree(dvector);
+  memory->sfree(iarray);
+  memory->sfree(darray);
+  memory->sfree(icols);
+  memory->sfree(dcols);
+
+  // delete user-defined molecules
+
+  for (int i = 0; i < nmolecule; i++) delete molecules[i];
+  memory->sfree(molecules);
+
+  // delete per-type arrays
+
+  delete[] mass;
+  delete[] mass_setflag;
+
+  // delete extra arrays
+
+  memory->destroy(extra_grow);
+  memory->destroy(extra_restart);
+  memory->destroy(extra_border);
+  memory->destroy(extra);
+
+  // delete mapping data structures
+
+  Atom::map_delete();
+
+  delete unique_tags;
+}
+
+/* ----------------------------------------------------------------------
+   copy modify settings from old Atom class to current Atom class
+------------------------------------------------------------------------- */
+
+void Atom::settings(Atom *old)
+{
+  tag_enable = old->tag_enable;
+  map_user = old->map_user;
+  map_style = old->map_style;
+  sortfreq = old->sortfreq;
+  userbinsize = old->userbinsize;
+  if (old->firstgroupname)
+    firstgroupname = utils::strdup(old->firstgroupname);
+}
+
+/* ----------------------------------------------------------------------
+   one-time creation of peratom data structure
+------------------------------------------------------------------------- */
+
+void Atom::peratom_create()
+{
+  peratom.clear();
+
+  // --------------------------------------------------------------------
+  // 2nd customization section: add peratom variables here, order does not matter
+  // register tagint & imageint variables as INT or BIGINT
+
+  int tagintsize = INT;
+  if (sizeof(tagint) == 8) tagintsize = BIGINT;
+  int imageintsize = INT;
+  if (sizeof(imageint) == 8) imageintsize = BIGINT;
+
+  add_peratom("id",&tag,tagintsize,0);
+  add_peratom("type",&type,INT,0);
+  add_peratom("mask",&mask,INT,0);
+  add_peratom("image",&image,imageintsize,0);
+
+  add_peratom("x",&x,DOUBLE,3);
+  add_peratom("v",&v,DOUBLE,3);
+  add_peratom("f",&f,DOUBLE,3,1);      // set per-thread flag
+
+  add_peratom("rmass",&rmass,DOUBLE,0);
+  add_peratom("q",&q,DOUBLE,0);
+  add_peratom("mu",&mu,DOUBLE,4);
+  add_peratom("mu3",&mu,DOUBLE,3);     // just first 3 values of mu[4]
+
+  // finite size particles
+
+  add_peratom("radius",&radius,DOUBLE,0);
+  add_peratom("omega",&omega,DOUBLE,3);
+  add_peratom("torque",&torque,DOUBLE,3,1);    // set per-thread flag
+  add_peratom("angmom",&angmom,DOUBLE,3);
+
+  add_peratom("ellipsoid",&ellipsoid,INT,0);
+  add_peratom("line",&line,INT,0);
+  add_peratom("tri",&tri,INT,0);
+  add_peratom("body",&body,INT,0);
+
+  // BPM package
+
+  add_peratom("quat",&quat,DOUBLE,4);
+
+  // MOLECULE package
+
+  add_peratom("molecule",&molecule,tagintsize,0);
+  add_peratom("molindex",&molindex,INT,0);
+  add_peratom("molatom",&molatom,INT,0);
+
+  add_peratom("nspecial",&nspecial,INT,3);
+  add_peratom_vary("special",&special,tagintsize,&maxspecial,&nspecial,3);
+
+  add_peratom("num_bond",&num_bond,INT,0);
+  add_peratom_vary("bond_type",&bond_type,INT,&bond_per_atom,&num_bond);
+  add_peratom_vary("bond_atom",&bond_atom,tagintsize,&bond_per_atom,&num_bond);
+
+  add_peratom("num_angle",&num_angle,INT,0);
+  add_peratom_vary("angle_type",&angle_type,INT,&angle_per_atom,&num_angle);
+  add_peratom_vary("angle_atom1",&angle_atom1,tagintsize,
+                   &angle_per_atom,&num_angle);
+  add_peratom_vary("angle_atom2",&angle_atom2,tagintsize,
+                   &angle_per_atom,&num_angle);
+  add_peratom_vary("angle_atom3",&angle_atom3,tagintsize,
+                   &angle_per_atom,&num_angle);
+
+  add_peratom("num_dihedral",&num_dihedral,INT,0);
+  add_peratom_vary("dihedral_type",&dihedral_type,INT,
+                   &dihedral_per_atom,&num_dihedral);
+  add_peratom_vary("dihedral_atom1",&dihedral_atom1,tagintsize,
+                   &dihedral_per_atom,&num_dihedral);
+  add_peratom_vary("dihedral_atom2",&dihedral_atom2,tagintsize,
+                   &dihedral_per_atom,&num_dihedral);
+  add_peratom_vary("dihedral_atom3",&dihedral_atom3,tagintsize,
+                   &dihedral_per_atom,&num_dihedral);
+  add_peratom_vary("dihedral_atom4",&dihedral_atom4,tagintsize,
+                   &dihedral_per_atom,&num_dihedral);
+
+  add_peratom("num_improper",&num_improper,INT,0);
+  add_peratom_vary("improper_type",&improper_type,INT,
+                   &improper_per_atom,&num_improper);
+  add_peratom_vary("improper_atom1",&improper_atom1,tagintsize,
+                   &improper_per_atom,&num_improper);
+  add_peratom_vary("improper_atom2",&improper_atom2,tagintsize,
+                   &improper_per_atom,&num_improper);
+  add_peratom_vary("improper_atom3",&improper_atom3,tagintsize,
+                   &improper_per_atom,&num_improper);
+  add_peratom_vary("improper_atom4",&improper_atom4,tagintsize,
+                   &improper_per_atom,&num_improper);
+
+  // PERI package
+
+  add_peratom("vfrac",&vfrac,DOUBLE,0);
+  add_peratom("s0",&s0,DOUBLE,0);
+  add_peratom("x0",&x0,DOUBLE,3);
+
+  // SPIN package
+
+  add_peratom("sp",&sp,DOUBLE,4);
+  add_peratom("fm",&fm,DOUBLE,3,1);
+  add_peratom("fm_long",&fm_long,DOUBLE,3,1);
+
+  // EFF package
+
+  add_peratom("spin",&spin,INT,0);
+  add_peratom("eradius",&eradius,DOUBLE,0);
+  add_peratom("ervel",&ervel,DOUBLE,0);
+  add_peratom("erforce",&erforce,DOUBLE,0,1);     // set per-thread flag
+
+  // AWPMD package
+
+  add_peratom("cs",&cs,DOUBLE,2);
+  add_peratom("csforce",&csforce,DOUBLE,2);
+  add_peratom("vforce",&vforce,DOUBLE,3);
+  add_peratom("ervelforce",&ervelforce,DOUBLE,0);
+  add_peratom("etag",&etag,INT,0);
+
+  // CG-DNA package
+
+  add_peratom("id5p",&id5p,tagintsize,0);
+
+  // DPD-REACT package
+
+  add_peratom("dpdTheta",&dpdTheta,DOUBLE,0);
+  add_peratom("uCond",&uCond,DOUBLE,0);
+  add_peratom("uMech",&uMech,DOUBLE,0);
+  add_peratom("uChem",&uChem,DOUBLE,0);
+  add_peratom("uCG",&uCG,DOUBLE,0);
+  add_peratom("uCGnew",&uCGnew,DOUBLE,0);
+  add_peratom("duChem",&duChem,DOUBLE,0);
+
+  // MESO package
+
+  add_peratom("edpd_cv",&edpd_cv,DOUBLE,0);
+  add_peratom("edpd_temp",&edpd_temp,DOUBLE,0);
+  add_peratom("vest_temp",&vest_temp,DOUBLE,0);
+  add_peratom("edpd_flux",&edpd_flux,DOUBLE,0,1);     // set per-thread flag
+  add_peratom("cc",&cc,DOUBLE,1);
+  add_peratom("cc_flux",&cc_flux,DOUBLE,1,1);         // set per-thread flag
+
+  // MESONT package
+
+  add_peratom("length",&length,DOUBLE,0);
+  add_peratom("buckling",&buckling,INT,0);
+  add_peratom("bond_nt",&bond_nt,tagintsize,2);
+
+  // SPH package
+
+  add_peratom("rho",&rho,DOUBLE,0);
+  add_peratom("drho",&drho,DOUBLE,0,1);               // set per-thread flag
+  add_peratom("esph",&esph,DOUBLE,0);
+  add_peratom("desph",&desph,DOUBLE,0,1);             // set per-thread flag
+  add_peratom("vest",&vest,DOUBLE,3);
+  add_peratom("cv",&cv,DOUBLE,0);
+
+  // MACHDYN package
+
+  add_peratom("contact_radius",&contact_radius,DOUBLE,0);
+  add_peratom("smd_data_9",&smd_data_9,DOUBLE,1);
+  add_peratom("smd_stress",&smd_stress,DOUBLE,1);
+  add_peratom("eff_plastic_strain",&eff_plastic_strain,DOUBLE,0);
+  add_peratom("eff_plastic_strain_rate",&eff_plastic_strain_rate,DOUBLE,0);
+  add_peratom("damage",&damage,DOUBLE,0);
+
+  // DIELECTRIC package
+
+  add_peratom("area",&area,DOUBLE,0);
+  add_peratom("ed",&ed,DOUBLE,0);
+  add_peratom("em",&em,DOUBLE,0);
+  add_peratom("epsilon",&epsilon,DOUBLE,0);
+  add_peratom("curvature",&curvature,DOUBLE,0);
+  add_peratom("q_unscaled",&q_unscaled,DOUBLE,0);
+
+  // AWSEM-MD package
+
+  add_peratom("residue",&residue,tagintsize,0);
+
+  // end of customization section
+  // --------------------------------------------------------------------
+}
+
+/* ----------------------------------------------------------------------
+   add info for a single per-atom vector/array to PerAtom data struct
+   cols = 0: per-atom vector
+   cols = N: static per-atom array with N columns
+   use add_peratom_vary() when column count varies per atom
+------------------------------------------------------------------------- */
+
+void Atom::add_peratom(const std::string &name, void *address,
+                       int datatype, int cols, int threadflag)
+{
+  PerAtom item = {name, address, nullptr, nullptr, datatype, cols, 0, threadflag};
+  peratom.push_back(item);
+}
+
+/* ----------------------------------------------------------------------
+   change the column count of an existing peratom array entry
+   allows atom_style to specify column count as an argument
+   see atom_style tdpd as an example
+------------------------------------------------------------------------- */
+
+void Atom::add_peratom_change_columns(const std::string &name, int cols)
+{
+  auto match = std::find_if(peratom.begin(), peratom.end(),
+                            [&name] (const PerAtom &p) { return p.name == name; });
+
+  if (match != peratom.end()) (*match).cols = cols;
+  else error->all(FLERR,"Could not find per-atom array name {} for column change", name);
+}
+
+/* ----------------------------------------------------------------------
+   add info for a single per-atom array to PerAtom data struct
+   cols = address of int variable with max columns per atom
+   for collength = 0:
+     length = address of peratom vector with column count per atom
+     e.g. num_bond
+   for collength = N:
+     length = address of peratom array with column count per atom
+     collength = index of column (1 to N) in peratom array with count
+     e.g. nspecial
+------------------------------------------------------------------------- */
+
+void Atom::add_peratom_vary(const std::string &name, void *address,
+                            int datatype, int *cols, void *length, int collength)
+{
+  PerAtom item = {name, address, length, cols, datatype, -1, collength, 0};
+  peratom.push_back(item);
+}
+
+/* ----------------------------------------------------------------------
+   add info for a single per-atom array to PerAtom data struct
+------------------------------------------------------------------------- */
+
+void Atom::set_atomflag_defaults()
+{
+  // --------------------------------------------------------------------
+  // 3rd customization section: customize by adding new flag
+  // identical list as 2nd customization in atom.h
+
+  sphere_flag = ellipsoid_flag = line_flag = tri_flag = body_flag = 0;
+  quat_flag = 0;
+  peri_flag = electron_flag = 0;
+  wavepacket_flag = sph_flag = 0;
+  molecule_flag = molindex_flag = molatom_flag = 0;
+  q_flag = mu_flag = 0;
+  rmass_flag = radius_flag = omega_flag = torque_flag = angmom_flag = 0;
+  vfrac_flag = spin_flag = eradius_flag = ervel_flag = erforce_flag = 0;
+  cs_flag = csforce_flag = vforce_flag = ervelforce_flag = etag_flag = 0;
+  rho_flag = esph_flag = cv_flag = vest_flag = 0;
+  dpd_flag = edpd_flag = tdpd_flag = 0;
+  sp_flag = 0;
+  x0_flag = 0;
+  smd_flag = damage_flag = 0;
+  mesont_flag = 0;
+  contact_radius_flag = smd_data_9_flag = smd_stress_flag = 0;
+  eff_plastic_strain_flag = eff_plastic_strain_rate_flag = 0;
+  residue_flag = 0;
+
+  pdscale = 1.0;
+}
+
+/* ----------------------------------------------------------------------
+   create an AtomVec style
+   called from lammps.cpp, input script, restart file, replicate
+------------------------------------------------------------------------- */
+
+void Atom::create_avec(const std::string &style, int narg, char **arg, int trysuffix)
+{
+  delete[] atom_style;
+  if (avec) delete avec;
+  atom_style = nullptr;
+  avec = nullptr;
+
+  // unset atom style and array existence flags
+  // may have been set by old avec
+
+  set_atomflag_defaults();
+
+  // create instance of AtomVec
+  // use grow() to initialize atom-based arrays to length 1
+  //   so that x[0][0] can always be referenced even if proc has no atoms
+
+  int sflag;
+  avec = new_avec(style,trysuffix,sflag);
+  avec->store_args(narg,arg);
+  avec->process_args(narg,arg);
+  avec->grow(1);
+
+  if (sflag) {
+    std::string estyle = style + "/";
+    if (sflag == 1) estyle += lmp->suffix;
+    else estyle += lmp->suffix2;
+    atom_style = utils::strdup(estyle);
+  } else {
+    atom_style = utils::strdup(style);
+  }
+
+  // if molecular system:
+  // atom IDs must be defined
+  // force atom map to be created
+  // map style will be reset to array vs hash to by map_init()
+
+  molecular = avec->molecular;
+  if ((molecular != Atom::ATOMIC) && (tag_enable == 0))
+    error->all(FLERR,"Atom IDs must be used for molecular systems");
+  if (molecular != Atom::ATOMIC) map_style = MAP_YES;
+}
+
+/* ----------------------------------------------------------------------
+   generate an AtomVec class, first with suffix appended
+------------------------------------------------------------------------- */
+
+AtomVec *Atom::new_avec(const std::string &style, int trysuffix, int &sflag)
+{
+  if (trysuffix && lmp->suffix_enable) {
+    if (lmp->suffix) {
+      sflag = 1;
+      std::string estyle = style + "/" + lmp->suffix;
+      if (avec_map->find(estyle) != avec_map->end()) {
+        AtomVecCreator &avec_creator = (*avec_map)[estyle];
+        return avec_creator(lmp);
+      }
+    }
+
+    if (lmp->suffix2) {
+      sflag = 2;
+      std::string estyle = style + "/" + lmp->suffix2;
+      if (avec_map->find(estyle) != avec_map->end()) {
+        AtomVecCreator &avec_creator = (*avec_map)[estyle];
+        return avec_creator(lmp);
+      }
+    }
+  }
+
+  sflag = 0;
+  if (avec_map->find(style) != avec_map->end()) {
+    AtomVecCreator &avec_creator = (*avec_map)[style];
+    return avec_creator(lmp);
+  }
+
+  error->all(FLERR,utils::check_packages_for_style("atom",style,lmp));
+  return nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Atom::init()
+{
+  // delete extra array since it doesn't persist past first run
+
+  if (nextra_store) {
+    memory->destroy(extra);
+    extra = nullptr;
+    nextra_store = 0;
+  }
+
+  // check arrays that are atom type in length
+
+  check_mass(FLERR);
+
+  // setup of firstgroup
+
+  if (firstgroupname) {
+    firstgroup = group->find(firstgroupname);
+    if (firstgroup < 0)
+      error->all(FLERR,"Could not find atom_modify first group ID {}", firstgroupname);
+  } else firstgroup = -1;
+
+  // init AtomVec
+
+  avec->init();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Atom::setup()
+{
+  // setup bins for sorting
+  // cannot do this in init() because uses neighbor cutoff
+
+  if (sortfreq > 0) setup_sort_bins();
+}
+
+/* ----------------------------------------------------------------------
+   return ptr to AtomVec class if matches style or to matching hybrid sub-class
+   return nullptr if no match
+------------------------------------------------------------------------- */
+
+AtomVec *Atom::style_match(const char *style)
+{
+  if (strcmp(atom_style,style) == 0) return avec;
+  else if (strcmp(atom_style,"hybrid") == 0) {
+    auto avec_hybrid = dynamic_cast<AtomVecHybrid *>( avec);
+    for (int i = 0; i < avec_hybrid->nstyles; i++)
+      if (strcmp(avec_hybrid->keywords[i],style) == 0)
+        return avec_hybrid->styles[i];
+  }
+  return nullptr;
+}
+
+/* ----------------------------------------------------------------------
+   modify parameters of the atom style
+   some options can only be invoked before simulation box is defined
+   first and sort options cannot be used together
+------------------------------------------------------------------------- */
+
+void Atom::modify_params(int narg, char **arg)
+{
+  if (narg == 0) utils::missing_cmd_args(FLERR, "atom_modify", error);
+
+  int iarg = 0;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"id") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "atom_modify id", error);
+      if (domain->box_exist)
+        error->all(FLERR,"Atom_modify id command after simulation box is defined");
+      tag_enable = utils::logical(FLERR,arg[iarg+1],false,lmp);
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"map") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "atom_modify map", error);
+      if (domain->box_exist)
+        error->all(FLERR,"Atom_modify map command after simulation box is defined");
+      if (strcmp(arg[iarg+1],"array") == 0) map_user = 1;
+      else if (strcmp(arg[iarg+1],"hash") == 0) map_user = 2;
+      else if (strcmp(arg[iarg+1],"yes") == 0) map_user = 3;
+      else error->all(FLERR,"Illegal atom_modify map command argument {}", arg[iarg+1]);
+      map_style = map_user;
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"first") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "atom_modify first", error);
+      if (strcmp(arg[iarg+1],"all") == 0) {
+        delete[] firstgroupname;
+        firstgroupname = nullptr;
+      } else {
+        firstgroupname = utils::strdup(arg[iarg+1]);
+        sortfreq = 0;
+      }
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"sort") == 0) {
+      if (iarg+3 > narg) utils::missing_cmd_args(FLERR, "atom_modify sort", error);
+      sortfreq = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
+      userbinsize = utils::numeric(FLERR,arg[iarg+2],false,lmp);
+      if (sortfreq < 0) error->all(FLERR,"Illegal atom_modify sort frequency {}", sortfreq);
+      if (userbinsize < 0.0) error->all(FLERR,"Illegal atom_modify sort bin size {}", userbinsize);
+      if ((sortfreq >= 0) && firstgroupname)
+        error->all(FLERR,"Atom_modify sort and first options cannot be used together");
+      iarg += 3;
+    } else error->all(FLERR,"Illegal atom_modify command argument: {}", arg[iarg]);
+  }
+}
+
+/* ----------------------------------------------------------------------
+   check that atom IDs are valid
+   error if any atom ID < 0 or atom ID = MAXTAGINT
+   if any atom ID > 0, error if any atom ID == 0
+   if any atom ID > 0, error if tag_enable = 0
+   if all atom IDs = 0, tag_enable must be 0
+   if max atom IDs < natoms, must be duplicates
+   OK if max atom IDs > natoms
+   NOTE: not fully checking that atom IDs are unique
+------------------------------------------------------------------------- */
+
+void Atom::tag_check()
+{
+  tagint min = MAXTAGINT;
+  tagint max = 0;
+
+  for (int i = 0; i < nlocal; i++) {
+    min = MIN(min,tag[i]);
+    max = MAX(max,tag[i]);
+  }
+
+  tagint minall,maxall;
+  MPI_Allreduce(&min,&minall,1,MPI_LMP_TAGINT,MPI_MIN,world);
+  MPI_Allreduce(&max,&maxall,1,MPI_LMP_TAGINT,MPI_MAX,world);
+
+  if (minall < 0) error->all(FLERR,"One or more Atom IDs are negative");
+  if (maxall >= MAXTAGINT) error->all(FLERR,"One or more atom IDs are too big");
+  if (maxall > 0 && minall == 0)
+    error->all(FLERR,"One or more atom IDs are zero");
+  if (maxall > 0 && tag_enable == 0)
+    error->all(FLERR,"Non-zero atom IDs with atom_modify id = no");
+  if (maxall == 0 && natoms && tag_enable)
+    error->all(FLERR,"All atom IDs = 0 but atom_modify id = yes");
+  if (tag_enable && maxall < natoms)
+    error->all(FLERR,"Duplicate atom IDs exist");
+}
+
+/* ----------------------------------------------------------------------
+   add unique tags to any atoms with tag = 0
+   new tags are grouped by proc and start after max current tag
+   called after creating new atoms
+   error if new tags will exceed MAXTAGINT
+------------------------------------------------------------------------- */
+
+void Atom::tag_extend()
+{
+  // maxtag_all = max tag for all atoms
+
+  tagint maxtag = 0;
+  for (int i = 0; i < nlocal; i++) maxtag = MAX(maxtag,tag[i]);
+  tagint maxtag_all;
+  MPI_Allreduce(&maxtag,&maxtag_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
+
+  // DEBUG: useful for generating 64-bit IDs even for small systems
+  // use only when LAMMPS is compiled with BIGBIG
+
+  //maxtag_all += 1000000000000;
+
+  // notag = # of atoms I own with no tag (tag = 0)
+  // notag_sum = # of total atoms on procs <= me with no tag
+
+  bigint notag = 0;
+  for (int i = 0; i < nlocal; i++) if (tag[i] == 0) notag++;
+
+  bigint notag_total;
+  MPI_Allreduce(&notag,&notag_total,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  if (notag_total >= MAXTAGINT)
+    error->all(FLERR,"New atom IDs exceed maximum allowed ID {}", MAXTAGINT);
+
+  bigint notag_sum;
+  MPI_Scan(&notag,&notag_sum,1,MPI_LMP_BIGINT,MPI_SUM,world);
+
+  // itag = 1st new tag that my untagged atoms should use
+
+  tagint itag = maxtag_all + notag_sum - notag + 1;
+  for (int i = 0; i < nlocal; i++) if (tag[i] == 0) tag[i] = itag++;
+}
+
+/* ----------------------------------------------------------------------
+   check that atom IDs span range from 1 to Natoms inclusive
+   return 0 if mintag != 1 or maxtag != Natoms
+   return 1 if OK
+   doesn't actually check if all tag values are used
+------------------------------------------------------------------------- */
+
+int Atom::tag_consecutive()
+{
+  tagint idmin = MAXTAGINT;
+  tagint idmax = 0;
+
+  for (int i = 0; i < nlocal; i++) {
+    idmin = MIN(idmin,tag[i]);
+    idmax = MAX(idmax,tag[i]);
+  }
+  tagint idminall,idmaxall;
+  MPI_Allreduce(&idmin,&idminall,1,MPI_LMP_TAGINT,MPI_MIN,world);
+  MPI_Allreduce(&idmax,&idmaxall,1,MPI_LMP_TAGINT,MPI_MAX,world);
+
+  if (idminall != 1 || idmaxall != natoms) return 0;
+  return 1;
+}
+
+/* ----------------------------------------------------------------------
+   check that bonus data settings are valid
+   error if number of atoms with ellipsoid/line/tri/body flags
+   are consistent with global setting.
+------------------------------------------------------------------------- */
+
+void Atom::bonus_check()
+{
+  bigint local_ellipsoids = 0, local_lines = 0, local_tris = 0;
+  bigint local_bodies = 0, num_global;
+
+  for (int i = 0; i < nlocal; ++i) {
+    if (ellipsoid && (ellipsoid[i] >=0)) ++local_ellipsoids;
+    if (line && (line[i] >=0)) ++local_lines;
+    if (tri && (tri[i] >=0)) ++local_tris;
+    if (body && (body[i] >=0)) ++local_bodies;
+  }
+
+  MPI_Allreduce(&local_ellipsoids,&num_global,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  if (nellipsoids != num_global)
+    error->all(FLERR,"Inconsistent 'ellipsoids' header value and number of "
+               "atoms with enabled ellipsoid flags");
+
+  MPI_Allreduce(&local_lines,&num_global,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  if (nlines != num_global)
+    error->all(FLERR,"Inconsistent 'lines' header value and number of "
+               "atoms with enabled line flags");
+
+  MPI_Allreduce(&local_tris,&num_global,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  if (ntris != num_global)
+    error->all(FLERR,"Inconsistent 'tris' header value and number of "
+               "atoms with enabled tri flags");
+
+  MPI_Allreduce(&local_bodies,&num_global,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  if (nbodies != num_global)
+    error->all(FLERR,"Inconsistent 'bodies' header value and number of "
+               "atoms with enabled body flags");
+}
+
+/* ----------------------------------------------------------------------
+   deallocate molecular topology arrays
+   done before realloc with (possibly) new 2nd dimension set to
+     correctly initialized per-atom values, e.g. bond_per_atom
+   needs to be called whenever 2nd dimensions are changed
+     and these arrays are already pre-allocated,
+     e.g. due to grow(1) in create_avec()
+------------------------------------------------------------------------- */
+
+void Atom::deallocate_topology()
+{
+  memory->destroy(atom->bond_type);
+  memory->destroy(atom->bond_atom);
+  atom->bond_type = nullptr;
+  atom->bond_atom = nullptr;
+
+  memory->destroy(atom->angle_type);
+  memory->destroy(atom->angle_atom1);
+  memory->destroy(atom->angle_atom2);
+  memory->destroy(atom->angle_atom3);
+  atom->angle_type = nullptr;
+  atom->angle_atom1 = atom->angle_atom2 = atom->angle_atom3 = nullptr;
+
+  memory->destroy(atom->dihedral_type);
+  memory->destroy(atom->dihedral_atom1);
+  memory->destroy(atom->dihedral_atom2);
+  memory->destroy(atom->dihedral_atom3);
+  memory->destroy(atom->dihedral_atom4);
+  atom->dihedral_type = nullptr;
+  atom->dihedral_atom1 = atom->dihedral_atom2 =
+    atom->dihedral_atom3 = atom->dihedral_atom4 = nullptr;
+
+  memory->destroy(atom->improper_type);
+  memory->destroy(atom->improper_atom1);
+  memory->destroy(atom->improper_atom2);
+  memory->destroy(atom->improper_atom3);
+  memory->destroy(atom->improper_atom4);
+  atom->improper_type = nullptr;
+  atom->improper_atom1 = atom->improper_atom2 =
+    atom->improper_atom3 = atom->improper_atom4 = nullptr;
+}
+
+/* ----------------------------------------------------------------------
+   unpack N lines from Atom section of data file
+   call style-specific routine to parse line
+------------------------------------------------------------------------- */
+
+void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
+                      int type_offset, int shiftflag, double *shift)
+{
+  int xptr,iptr;
+  imageint imagedata;
+  double xdata[3],lamda[3];
+  double *coord;
+  char *next;
+
+  // use the first line to detect and validate the number of words/tokens per line
+  next = strchr(buf,'\n');
+  if (!next) error->all(FLERR, "Missing data in Atoms section of data file");
+  *next = '\0';
+  int nwords = utils::trim_and_count_words(buf);
+  *next = '\n';
+
+  if ((nwords != avec->size_data_atom) && (nwords != avec->size_data_atom + 3))
+    error->all(FLERR,"Incorrect atom format in data file: {}", utils::trim(buf));
+
+  // set bounds for my proc
+  // if periodic and I am lo/hi proc, adjust bounds by EPSILON
+  // insures all data atoms will be owned even with round-off
+
+  int triclinic = domain->triclinic;
+
+  double epsilon[3];
+  if (triclinic) epsilon[0] = epsilon[1] = epsilon[2] = EPSILON;
+  else {
+    epsilon[0] = domain->prd[0] * EPSILON;
+    epsilon[1] = domain->prd[1] * EPSILON;
+    epsilon[2] = domain->prd[2] * EPSILON;
+  }
+
+  double sublo[3],subhi[3];
+  if (triclinic == 0) {
+    sublo[0] = domain->sublo[0]; subhi[0] = domain->subhi[0];
+    sublo[1] = domain->sublo[1]; subhi[1] = domain->subhi[1];
+    sublo[2] = domain->sublo[2]; subhi[2] = domain->subhi[2];
+  } else {
+    sublo[0] = domain->sublo_lamda[0]; subhi[0] = domain->subhi_lamda[0];
+    sublo[1] = domain->sublo_lamda[1]; subhi[1] = domain->subhi_lamda[1];
+    sublo[2] = domain->sublo_lamda[2]; subhi[2] = domain->subhi_lamda[2];
+  }
+
+  if (comm->layout != Comm::LAYOUT_TILED) {
+    if (domain->xperiodic) {
+      if (comm->myloc[0] == 0) sublo[0] -= epsilon[0];
+      if (comm->myloc[0] == comm->procgrid[0]-1) subhi[0] += epsilon[0];
+    }
+    if (domain->yperiodic) {
+      if (comm->myloc[1] == 0) sublo[1] -= epsilon[1];
+      if (comm->myloc[1] == comm->procgrid[1]-1) subhi[1] += epsilon[1];
+    }
+    if (domain->zperiodic) {
+      if (comm->myloc[2] == 0) sublo[2] -= epsilon[2];
+      if (comm->myloc[2] == comm->procgrid[2]-1) subhi[2] += epsilon[2];
+    }
+
+  } else {
+    if (domain->xperiodic) {
+      if (comm->mysplit[0][0] == 0.0) sublo[0] -= epsilon[0];
+      if (comm->mysplit[0][1] == 1.0) subhi[0] += epsilon[0];
+    }
+    if (domain->yperiodic) {
+      if (comm->mysplit[1][0] == 0.0) sublo[1] -= epsilon[1];
+      if (comm->mysplit[1][1] == 1.0) subhi[1] += epsilon[1];
+    }
+    if (domain->zperiodic) {
+      if (comm->mysplit[2][0] == 0.0) sublo[2] -= epsilon[2];
+      if (comm->mysplit[2][1] == 1.0) subhi[2] += epsilon[2];
+    }
+  }
+
+  // xptr = which word in line starts xyz coords
+  // iptr = which word in line starts ix,iy,iz image flags
+
+  xptr = avec->xcol_data - 1;
+  int imageflag = 0;
+  if (nwords > avec->size_data_atom) imageflag = 1;
+  if (imageflag) iptr = nwords - 3;
+
+  // loop over lines of atom data
+  // tokenize the line into values
+  // extract xyz coords and image flags
+  // remap atom into simulation box
+  // if atom is in my sub-domain, unpack its values
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Atoms section of data file");
+    *next = '\0';
+    auto values = Tokenizer(utils::trim_comment(buf)).as_vector();
+    if (values.size() == 0) {
+      // skip over empty or comment lines
+    } else if ((int)values.size() != nwords) {
+      error->all(FLERR, "Incorrect atom format in data file: {}", utils::trim(buf));
+    } else {
+      int imx = 0, imy = 0, imz = 0;
+      if (imageflag) {
+        imx = utils::inumeric(FLERR,values[iptr],false,lmp);
+        imy = utils::inumeric(FLERR,values[iptr+1],false,lmp);
+        imz = utils::inumeric(FLERR,values[iptr+2],false,lmp);
+        if ((domain->dimension == 2) && (imz != 0))
+          error->all(FLERR,"Z-direction image flag must be 0 for 2d-systems");
+        if ((!domain->xperiodic) && (imx != 0)) { reset_image_flag[0] = true; imx = 0; }
+        if ((!domain->yperiodic) && (imy != 0)) { reset_image_flag[1] = true; imy = 0; }
+        if ((!domain->zperiodic) && (imz != 0)) { reset_image_flag[2] = true; imz = 0; }
+      }
+      imagedata = ((imageint) (imx + IMGMAX) & IMGMASK) |
+        (((imageint) (imy + IMGMAX) & IMGMASK) << IMGBITS) |
+        (((imageint) (imz + IMGMAX) & IMGMASK) << IMG2BITS);
+
+      xdata[0] = utils::numeric(FLERR,values[xptr],false,lmp);
+      xdata[1] = utils::numeric(FLERR,values[xptr+1],false,lmp);
+      xdata[2] = utils::numeric(FLERR,values[xptr+2],false,lmp);
+      if (shiftflag) {
+        xdata[0] += shift[0];
+        xdata[1] += shift[1];
+        xdata[2] += shift[2];
+      }
+
+      domain->remap(xdata,imagedata);
+      if (triclinic) {
+        domain->x2lamda(xdata,lamda);
+        coord = lamda;
+      } else coord = xdata;
+
+      if (coord[0] >= sublo[0] && coord[0] < subhi[0] &&
+          coord[1] >= sublo[1] && coord[1] < subhi[1] &&
+          coord[2] >= sublo[2] && coord[2] < subhi[2]) {
+        avec->data_atom(xdata,imagedata,values);
+        if (id_offset) tag[nlocal-1] += id_offset;
+        if (mol_offset) molecule[nlocal-1] += mol_offset;
+        if (type_offset) {
+          type[nlocal-1] += type_offset;
+          if (type[nlocal-1] > ntypes)
+            error->one(FLERR,"Invalid atom type in Atoms section of data file");
+        }
+      }
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   unpack N lines from Velocity section of data file
+   check that atom IDs are > 0 and <= map_tag_max
+   call style-specific routine to parse line
+------------------------------------------------------------------------- */
+
+void Atom::data_vels(int n, char *buf, tagint id_offset)
+{
+  int m;
+  char *next;
+
+  // loop over lines of atom velocities
+  // tokenize the line into values
+  // if I own atom tag, unpack its values
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Velocities section of data file");
+    *next = '\0';
+    auto values = Tokenizer(utils::trim_comment(buf)).as_vector();
+    if (values.size() == 0) {
+      // skip over empty or comment lines
+    } else if ((int)values.size() != avec->size_data_vel) {
+      error->all(FLERR, "Incorrect velocity format in data file: {}", utils::trim(buf));
+    } else {
+      tagint tagdata = utils::tnumeric(FLERR,values[0],false,lmp) + id_offset;
+      if (tagdata <= 0 || tagdata > map_tag_max)
+        error->one(FLERR,"Invalid atom ID {} in Velocities section of data file: {}", tagdata, buf);
+      if ((m = map(tagdata)) >= 0) avec->data_vel(m,values);
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   process N bonds read into buf from data files
+   if count is non-nullptr, just count bonds per atom
+   else store them with atoms
+   check that atom IDs are > 0 and <= map_tag_max
+------------------------------------------------------------------------- */
+
+void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
+                      int type_offset)
+{
+  int m,itype;
+  tagint atom1,atom2;
+  char *next;
+  int newton_bond = force->newton_bond;
+  auto location = "Bonds section of data file";
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Bonds section of data file");
+    *next = '\0';
+    ValueTokenizer values(utils::trim_comment(buf));
+    // skip over empty of comment lines
+    if (values.has_next()) {
+      try {
+        values.next_int();
+        itype = values.next_int();
+        atom1 = values.next_tagint();
+        atom2 = values.next_tagint();
+        if (values.has_next()) throw TokenizerException("Too many tokens","");
+      } catch (TokenizerException &e) {
+        error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
+      }
+      if (id_offset) {
+        atom1 += id_offset;
+        atom2 += id_offset;
+      }
+      itype += type_offset;
+
+      if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+          (atom2 <= 0) || (atom2 > map_tag_max) || (atom1 == atom2))
+        error->one(FLERR,"Invalid atom ID in {}: {}", location, utils::trim(buf));
+      if (itype <= 0 || itype > nbondtypes)
+        error->one(FLERR,"Invalid bond type in {}: {}", location, utils::trim(buf));
+      if ((m = map(atom1)) >= 0) {
+        if (count) count[m]++;
+        else {
+          bond_type[m][num_bond[m]] = itype;
+          bond_atom[m][num_bond[m]] = atom2;
+          num_bond[m]++;
+          avec->data_bonds_post(m, num_bond[m], atom1, atom2, id_offset);
+        }
+      }
+      if (newton_bond == 0) {
+        if ((m = map(atom2)) >= 0) {
+          if (count) count[m]++;
+          else {
+            bond_type[m][num_bond[m]] = itype;
+            bond_atom[m][num_bond[m]] = atom1;
+            num_bond[m]++;
+            avec->data_bonds_post(m, num_bond[m], atom1, atom2, id_offset);
+          }
+        }
+      }
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   process N angles read into buf from data files
+   if count is non-nullptr, just count angles per atom
+   else store them with atoms
+   check that atom IDs are > 0 and <= map_tag_max
+------------------------------------------------------------------------- */
+
+void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
+                       int type_offset)
+{
+  int m,itype;
+  tagint atom1,atom2,atom3;
+  char *next;
+  int newton_bond = force->newton_bond;
+  auto location = "Angles section of data file";
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Angles section of data file");
+    *next = '\0';
+    ValueTokenizer values(utils::trim_comment(buf));
+    // skip over empty or comment lines
+    if (values.has_next()) {
+      try {
+        values.next_int();
+        itype = values.next_int();
+        atom1 = values.next_tagint();
+        atom2 = values.next_tagint();
+        atom3 = values.next_tagint();
+        if (values.has_next()) throw TokenizerException("Too many tokens","");
+      } catch (TokenizerException &e) {
+        error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
+      }
+      if (id_offset) {
+        atom1 += id_offset;
+        atom2 += id_offset;
+        atom3 += id_offset;
+      }
+      itype += type_offset;
+
+      if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+          (atom2 <= 0) || (atom2 > map_tag_max) ||
+          (atom3 <= 0) || (atom3 > map_tag_max) ||
+          (atom1 == atom2) || (atom1 == atom3) || (atom2 == atom3))
+        error->one(FLERR,"Invalid atom ID in {}: {}", location, utils::trim(buf));
+      if (itype <= 0 || itype > nangletypes)
+        error->one(FLERR,"Invalid angle type in {}: {}", location, utils::trim(buf));
+      if ((m = map(atom2)) >= 0) {
+        if (count) count[m]++;
+        else {
+          angle_type[m][num_angle[m]] = itype;
+          angle_atom1[m][num_angle[m]] = atom1;
+          angle_atom2[m][num_angle[m]] = atom2;
+          angle_atom3[m][num_angle[m]] = atom3;
+          num_angle[m]++;
+        }
+      }
+      if (newton_bond == 0) {
+        if ((m = map(atom1)) >= 0) {
+          if (count) count[m]++;
+          else {
+            angle_type[m][num_angle[m]] = itype;
+            angle_atom1[m][num_angle[m]] = atom1;
+            angle_atom2[m][num_angle[m]] = atom2;
+            angle_atom3[m][num_angle[m]] = atom3;
+            num_angle[m]++;
+          }
+        }
+        if ((m = map(atom3)) >= 0) {
+          if (count) count[m]++;
+          else {
+            angle_type[m][num_angle[m]] = itype;
+            angle_atom1[m][num_angle[m]] = atom1;
+            angle_atom2[m][num_angle[m]] = atom2;
+            angle_atom3[m][num_angle[m]] = atom3;
+            num_angle[m]++;
+          }
+        }
+      }
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   process N dihedrals read into buf from data files
+   if count is non-nullptr, just count diihedrals per atom
+   else store them with atoms
+   check that atom IDs are > 0 and <= map_tag_max
+------------------------------------------------------------------------- */
+
+void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
+                          int type_offset)
+{
+  int m,itype;
+  tagint atom1,atom2,atom3,atom4;
+  char *next;
+  int newton_bond = force->newton_bond;
+  auto location = "Dihedrals section of data file";
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Dihedrals section of data file");
+    *next = '\0';
+    ValueTokenizer values(utils::trim_comment(buf));
+    // skip over empty or comment lines
+    if (values.has_next()) {
+      try {
+        values.next_int();
+        itype = values.next_int();
+        atom1 = values.next_tagint();
+        atom2 = values.next_tagint();
+        atom3 = values.next_tagint();
+        atom4 = values.next_tagint();
+        if (values.has_next()) throw TokenizerException("Too many tokens","");
+      } catch (TokenizerException &e) {
+        error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
+      }
+      if (id_offset) {
+        atom1 += id_offset;
+        atom2 += id_offset;
+        atom3 += id_offset;
+        atom4 += id_offset;
+      }
+      itype += type_offset;
+
+      if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+          (atom2 <= 0) || (atom2 > map_tag_max) ||
+          (atom3 <= 0) || (atom3 > map_tag_max) ||
+          (atom4 <= 0) || (atom4 > map_tag_max) ||
+          (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+          (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
+        error->one(FLERR, "Invalid atom ID in {}: {}", location, utils::trim(buf));
+      if (itype <= 0 || itype > ndihedraltypes)
+        error->one(FLERR, "Invalid dihedral type in {}: {}", location, utils::trim(buf));
+      if ((m = map(atom2)) >= 0) {
+        if (count) count[m]++;
+        else {
+          dihedral_type[m][num_dihedral[m]] = itype;
+          dihedral_atom1[m][num_dihedral[m]] = atom1;
+          dihedral_atom2[m][num_dihedral[m]] = atom2;
+          dihedral_atom3[m][num_dihedral[m]] = atom3;
+          dihedral_atom4[m][num_dihedral[m]] = atom4;
+          num_dihedral[m]++;
+        }
+      }
+      if (newton_bond == 0) {
+        if ((m = map(atom1)) >= 0) {
+          if (count) count[m]++;
+          else {
+            dihedral_type[m][num_dihedral[m]] = itype;
+            dihedral_atom1[m][num_dihedral[m]] = atom1;
+            dihedral_atom2[m][num_dihedral[m]] = atom2;
+            dihedral_atom3[m][num_dihedral[m]] = atom3;
+            dihedral_atom4[m][num_dihedral[m]] = atom4;
+            num_dihedral[m]++;
+          }
+        }
+        if ((m = map(atom3)) >= 0) {
+          if (count) count[m]++;
+          else {
+            dihedral_type[m][num_dihedral[m]] = itype;
+            dihedral_atom1[m][num_dihedral[m]] = atom1;
+            dihedral_atom2[m][num_dihedral[m]] = atom2;
+            dihedral_atom3[m][num_dihedral[m]] = atom3;
+            dihedral_atom4[m][num_dihedral[m]] = atom4;
+            num_dihedral[m]++;
+          }
+        }
+        if ((m = map(atom4)) >= 0) {
+          if (count) count[m]++;
+          else {
+            dihedral_type[m][num_dihedral[m]] = itype;
+            dihedral_atom1[m][num_dihedral[m]] = atom1;
+            dihedral_atom2[m][num_dihedral[m]] = atom2;
+            dihedral_atom3[m][num_dihedral[m]] = atom3;
+            dihedral_atom4[m][num_dihedral[m]] = atom4;
+            num_dihedral[m]++;
+          }
+        }
+      }
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   process N impropers read into buf from data files
+   if count is non-nullptr, just count impropers per atom
+   else store them with atoms
+   check that atom IDs are > 0 and <= map_tag_max
+------------------------------------------------------------------------- */
+
+void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
+                          int type_offset)
+{
+  int m,itype;
+  tagint atom1,atom2,atom3,atom4;
+  char *next;
+  int newton_bond = force->newton_bond;
+  auto location = "Impropers section of data file";
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Impropers section of data file");
+    *next = '\0';
+    ValueTokenizer values(utils::trim_comment(buf));
+    // skip over empty or comment lines
+    if (values.has_next()) {
+      try {
+        values.next_int();
+        itype = values.next_int();
+        atom1 = values.next_tagint();
+        atom2 = values.next_tagint();
+        atom3 = values.next_tagint();
+        atom4 = values.next_tagint();
+        if (values.has_next()) throw TokenizerException("Too many tokens","");
+      } catch (TokenizerException &e) {
+        error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
+      }
+      if (id_offset) {
+        atom1 += id_offset;
+        atom2 += id_offset;
+        atom3 += id_offset;
+        atom4 += id_offset;
+      }
+      itype += type_offset;
+
+      if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+          (atom2 <= 0) || (atom2 > map_tag_max) ||
+          (atom3 <= 0) || (atom3 > map_tag_max) ||
+          (atom4 <= 0) || (atom4 > map_tag_max) ||
+          (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+          (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
+        error->one(FLERR, "Invalid atom ID in {}: {}", location, utils::trim(buf));
+      if (itype <= 0 || itype > nimpropertypes)
+        error->one(FLERR, "Invalid improper type in {}: {}", location, utils::trim(buf));
+      if ((m = map(atom2)) >= 0) {
+        if (count) count[m]++;
+        else {
+          improper_type[m][num_improper[m]] = itype;
+          improper_atom1[m][num_improper[m]] = atom1;
+          improper_atom2[m][num_improper[m]] = atom2;
+          improper_atom3[m][num_improper[m]] = atom3;
+          improper_atom4[m][num_improper[m]] = atom4;
+          num_improper[m]++;
+        }
+      }
+      if (newton_bond == 0) {
+        if ((m = map(atom1)) >= 0) {
+          if (count) count[m]++;
+          else {
+            improper_type[m][num_improper[m]] = itype;
+            improper_atom1[m][num_improper[m]] = atom1;
+            improper_atom2[m][num_improper[m]] = atom2;
+            improper_atom3[m][num_improper[m]] = atom3;
+            improper_atom4[m][num_improper[m]] = atom4;
+            num_improper[m]++;
+          }
+        }
+        if ((m = map(atom3)) >= 0) {
+          if (count) count[m]++;
+          else {
+            improper_type[m][num_improper[m]] = itype;
+            improper_atom1[m][num_improper[m]] = atom1;
+            improper_atom2[m][num_improper[m]] = atom2;
+            improper_atom3[m][num_improper[m]] = atom3;
+            improper_atom4[m][num_improper[m]] = atom4;
+            num_improper[m]++;
+          }
+        }
+        if ((m = map(atom4)) >= 0) {
+          if (count) count[m]++;
+          else {
+            improper_type[m][num_improper[m]] = itype;
+            improper_atom1[m][num_improper[m]] = atom1;
+            improper_atom2[m][num_improper[m]] = atom2;
+            improper_atom3[m][num_improper[m]] = atom3;
+            improper_atom4[m][num_improper[m]] = atom4;
+            num_improper[m]++;
+          }
+        }
+      }
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   unpack N lines from atom-style specific bonus section of data file
+   check that atom IDs are > 0 and <= map_tag_max
+   call style-specific routine to parse line
+------------------------------------------------------------------------- */
+
+void Atom::data_bonus(int n, char *buf, AtomVec *avec_bonus, tagint id_offset)
+{
+  int m;
+  char *next;
+
+  // loop over lines of bonus atom data
+  // tokenize the line into values
+  // if I own atom tag, unpack its values
+
+  for (int i = 0; i < n; i++) {
+    next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Bonus section of data file");
+    *next = '\0';
+    auto values = Tokenizer(utils::trim_comment(buf)).as_vector();
+    if (values.size() == 0) {
+      // skip over empty or comment lines
+    } else if ((int)values.size() != avec_bonus->size_data_bonus) {
+      error->all(FLERR, "Incorrect bonus data format in data file: {}", utils::trim(buf));
+    } else {
+      tagint tagdata = utils::tnumeric(FLERR,values[0],false,lmp) + id_offset;
+      if (tagdata <= 0 || tagdata > map_tag_max)
+        error->one(FLERR,"Invalid atom ID in Bonus section of data file");
+
+      // ok to call child's data_atom_bonus() method thru parent avec_bonus,
+      // since data_bonus() was called with child ptr, and method is virtual
+
+      if ((m = map(tagdata)) >= 0) avec_bonus->data_atom_bonus(m,values);
+    }
+    buf = next + 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   unpack N bodies from Bodies section of data file
+   each body spans multiple lines
+   check that atom IDs are > 0 and <= map_tag_max
+   call style-specific routine to parse line
+------------------------------------------------------------------------- */
+
+void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
+{
+  std::vector<int> ivalues;
+  std::vector<double> dvalues;
+
+  if (!unique_tags) unique_tags = new std::set<tagint>;
+
+  // loop over lines of body data
+  // if I own atom tag, tokenize lines into ivalues/dvalues, call data_body()
+  // else skip values
+
+  for (int i = 0; i < n; i++) {
+    char *next = strchr(buf,'\n');
+    if (!next) error->all(FLERR, "Missing data in Bodies section of data file");
+    *next = '\0';
+
+    auto values = Tokenizer(utils::trim_comment(buf)).as_vector();
+    if (values.size()) {
+      tagint tagdata = utils::tnumeric(FLERR,values[0],false,lmp) + id_offset;
+      int ninteger = utils::inumeric(FLERR,values[1],false,lmp);
+      int ndouble = utils::inumeric(FLERR,values[2],false,lmp);
+
+      if (unique_tags->find(tagdata) == unique_tags->end())
+        unique_tags->insert(tagdata);
+      else
+        error->one(FLERR,"Duplicate atom ID {} in Bodies section of data file", tagdata);
+
+      buf = next + 1;
+      int m = map(tagdata);
+      if (m >= 0) {
+        ivalues.resize(ninteger);
+        dvalues.resize(ndouble);
+
+        for (int j = 0; j < ninteger; j++) {
+          buf += strspn(buf," \t\n\r\f");
+          buf[strcspn(buf," \t\n\r\f")] = '\0';
+          ivalues[j] = utils::inumeric(FLERR,buf,false,lmp);
+          buf += strlen(buf)+1;
+        }
+
+        for (int j = 0; j < ndouble; j++) {
+          buf += strspn(buf," \t\n\r\f");
+          buf[strcspn(buf," \t\n\r\f")] = '\0';
+          dvalues[j] = utils::numeric(FLERR,buf,false,lmp);
+          buf += strlen(buf)+1;
+        }
+
+        avec_body->data_body(m,ninteger,ndouble,ivalues.data(),dvalues.data());
+
+      } else {
+        int nvalues = ninteger + ndouble;    // number of values to skip
+        for (int j = 0; j < nvalues; j++) {
+          buf += strspn(buf," \t\n\r\f");
+          buf[strcspn(buf," \t\n\r\f")] = '\0';
+          buf += strlen(buf)+1;
+        }
+      }
+    }
+    buf += strspn(buf," \t\n\r\f");
+  }
+}
+
+/* ----------------------------------------------------------------------
+   init per-atom fix/compute/variable values for newly created atoms
+   called from create_atoms, read_data, read_dump,
+     lib::lammps_create_atoms()
+   fixes, computes, variables may or may not exist when called
+------------------------------------------------------------------------- */
+
+void Atom::data_fix_compute_variable(int nprev, int nnew)
+{
+  for (const auto &fix : modify->get_fix_list()) {
+    if (fix->create_attribute)
+      for (int i = nprev; i < nnew; i++)
+        fix->set_arrays(i);
+  }
+
+  for (int m = 0; m < modify->ncompute; m++) {
+    Compute *compute = modify->compute[m];
+    if (compute->create_attribute)
+      for (int i = nprev; i < nnew; i++)
+        compute->set_arrays(i);
+  }
+
+  for (int i = nprev; i < nnew; i++)
+    input->variable->set_arrays(i);
+}
+
+/* ----------------------------------------------------------------------
+   allocate arrays of length ntypes
+   only done after ntypes is set
+------------------------------------------------------------------------- */
+
+void Atom::allocate_type_arrays()
+{
+  if (avec->mass_type == AtomVec::PER_TYPE) {
+    mass = new double[ntypes+1];
+    mass_setflag = new int[ntypes+1];
+    for (int itype = 1; itype <= ntypes; itype++) mass_setflag[itype] = 0;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   set a mass and flag it as set
+   called from reading of data file
+   type_offset may be used when reading multiple data files
+------------------------------------------------------------------------- */
+
+void Atom::set_mass(const char *file, int line, const char *str, int type_offset)
+{
+  if (mass == nullptr) error->all(file,line,"Cannot set mass for atom style {}", atom_style);
+
+  int itype;
+  double mass_one;
+  ValueTokenizer values(utils::trim_comment(str));
+  if (values.has_next()) {
+    try {
+      itype = values.next_int() + type_offset;
+      mass_one = values.next_double();
+      if (values.has_next()) throw TokenizerException("Too many tokens", "");
+
+      if (itype < 1 || itype > ntypes) throw TokenizerException("Invalid atom type", "");
+      if (mass_one <= 0.0) throw TokenizerException("Invalid mass value", "");
+    } catch (TokenizerException &e) {
+      error->all(file,line,"{} in Masses section of data file: {}", e.what(), utils::trim(str));
+    }
+
+    mass[itype] = mass_one;
+    mass_setflag[itype] = 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   set a mass and flag it as set
+   called from EAM pair routine
+------------------------------------------------------------------------- */
+
+void Atom::set_mass(const char *file, int line, int itype, double value)
+{
+  if (mass == nullptr) error->all(file,line, "Cannot set mass for atom style {}", atom_style);
+  if (itype < 1 || itype > ntypes)
+    error->all(file,line,"Invalid type {} for atom mass {}", itype, value);
+  if (value <= 0.0) error->all(file,line,"Invalid atom mass value {}", value);
+
+  mass[itype] = value;
+  mass_setflag[itype] = 1;
+}
+
+/* ----------------------------------------------------------------------
+   set one or more masses and flag them as set
+   called from reading of input script
+------------------------------------------------------------------------- */
+
+void Atom::set_mass(const char *file, int line, int /*narg*/, char **arg)
+{
+  if (mass == nullptr) error->all(file,line, "Cannot set atom mass for atom style {}", atom_style);
+
+  int lo,hi;
+  utils::bounds(file,line,arg[0],1,ntypes,lo,hi,error);
+  if ((lo < 1) || (hi > ntypes))
+    error->all(file,line,"Invalid type {} for atom mass {}", arg[1]);
+
+  const double value = utils::numeric(FLERR,arg[1],false,lmp);
+  if (value <= 0.0) error->all(file,line,"Invalid atom mass value {}", value);
+
+  for (int itype = lo; itype <= hi; itype++) {
+    mass[itype] = value;
+    mass_setflag[itype] = 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   set all masses
+   called from reading of restart file, also from ServerMD
+------------------------------------------------------------------------- */
+
+void Atom::set_mass(double *values)
+{
+  for (int itype = 1; itype <= ntypes; itype++) {
+    mass[itype] = values[itype];
+    mass_setflag[itype] = 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   check that all per-atom-type masses have been set
+------------------------------------------------------------------------- */
+
+void Atom::check_mass(const char *file, int line)
+{
+  if (mass == nullptr) return;
+  if (rmass_flag) return;
+  for (int itype = 1; itype <= ntypes; itype++)
+    if (mass_setflag[itype] == 0)
+      error->all(file,line,"Not all per-type masses are set. Type {} is missing.", itype);
+}
+
+/* ----------------------------------------------------------------------
+   check that radii of all particles of itype are the same
+   return 1 if true, else return 0
+   also return the radius value for that type
+------------------------------------------------------------------------- */
+
+int Atom::radius_consistency(int itype, double &rad)
+{
+  double value = -1.0;
+  int flag = 0;
+  for (int i = 0; i < nlocal; i++) {
+    if (type[i] != itype) continue;
+    if (value < 0.0) value = radius[i];
+    else if (value != radius[i]) flag = 1;
+  }
+
+  int flagall;
+  MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
+  if (flagall) return 0;
+
+  MPI_Allreduce(&value,&rad,1,MPI_DOUBLE,MPI_MAX,world);
+  return 1;
+}
+
+/* ----------------------------------------------------------------------
+   check that shape of all particles of itype are the same
+   return 1 if true, else return 0
+   also return the 3 shape params for itype
+------------------------------------------------------------------------- */
+
+int Atom::shape_consistency(int itype, double &shapex, double &shapey, double &shapez)
+{
+  double zero[3] = {0.0, 0.0, 0.0};
+  double one[3] = {-1.0, -1.0, -1.0};
+  double *shape;
+
+  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>( style_match("ellipsoid"));
+  auto bonus = avec_ellipsoid->bonus;
+
+  int flag = 0;
+  for (int i = 0; i < nlocal; i++) {
+    if (type[i] != itype) continue;
+    if (ellipsoid[i] < 0) shape = zero;
+    else shape = bonus[ellipsoid[i]].shape;
+
+    if (one[0] < 0.0) {
+      one[0] = shape[0];
+      one[1] = shape[1];
+      one[2] = shape[2];
+    } else if ((one[0] != shape[0]) || (one[1] != shape[1]) || (one[2] != shape[2]))
+      flag = 1;
+  }
+
+  int flagall;
+  MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
+  if (flagall) return 0;
+
+  double oneall[3];
+  MPI_Allreduce(one,oneall,3,MPI_DOUBLE,MPI_MAX,world);
+  shapex = oneall[0];
+  shapey = oneall[1];
+  shapez = oneall[2];
+  return 1;
+}
+
+/* ----------------------------------------------------------------------
+   add a new molecule template = set of molecules
+------------------------------------------------------------------------- */
+
+void Atom::add_molecule(int narg, char **arg)
+{
+  if (narg < 1) utils::missing_cmd_args(FLERR, "molecule", error);
+
+  if (find_molecule(arg[0]) >= 0)
+    error->all(FLERR,"Reuse of molecule template ID {}", arg[0]);
+
+  // 1st molecule in set stores nset = # of mols, others store nset = 0
+  // ifile = count of molecules in set
+  // index = argument index where next molecule starts, updated by constructor
+
+  int ifile = 1;
+  int index = 1;
+  while (true) {
+    molecules = (Molecule **)
+      memory->srealloc(molecules,(nmolecule+1)*sizeof(Molecule *), "atom::molecules");
+    molecules[nmolecule] = new Molecule(lmp,narg,arg,index);
+    molecules[nmolecule]->nset = 0;
+    molecules[nmolecule-ifile+1]->nset++;
+    nmolecule++;
+    if (molecules[nmolecule-1]->last) break;
+    ifile++;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   find first molecule in set with template ID
+   return -1 if does not exist
+------------------------------------------------------------------------- */
+
+int Atom::find_molecule(char *id)
+{
+  if (id == nullptr) return -1;
+  int imol;
+  for (imol = 0; imol < nmolecule; imol++)
+    if (strcmp(id,molecules[imol]->id) == 0) return imol;
+  return -1;
+}
+
+/* ----------------------------------------------------------------------
+   add info to current atom ilocal from molecule template onemol and its iatom
+   offset = atom ID preceding IDs of atoms in this molecule
+   called by fixes and commands that add molecules
+------------------------------------------------------------------------- */
+
+void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint offset)
+{
+  if (onemol->qflag && q_flag) q[ilocal] = onemol->q[iatom];
+  if (onemol->radiusflag && radius_flag) radius[ilocal] = onemol->radius[iatom];
+  if (onemol->rmassflag && rmass_flag) rmass[ilocal] = onemol->rmass[iatom];
+  else if (rmass_flag)
+    rmass[ilocal] = 4.0*MY_PI/3.0 *
+      radius[ilocal]*radius[ilocal]*radius[ilocal];
+  if (onemol->bodyflag) {
+    body[ilocal] = 0;     // as if a body read from data file
+    onemol->avec_body->data_body(ilocal,onemol->nibody,onemol->ndbody,
+                                 onemol->ibodyparams,onemol->dbodyparams);
+    onemol->avec_body->set_quat(ilocal,onemol->quat_external);
+  }
+
+  // initialize custom per-atom properties to zero if present
+
+  for (int i = 0; i < nivector; ++i)
+    ivector[i][ilocal] = 0;
+  for (int i = 0; i < ndvector; ++i)
+    dvector[i][ilocal] = 0.0;
+  for (int i = 0; i < niarray; ++i)
+    for (int j = 0; j < icols[i]; ++j)
+      iarray[i][ilocal][j] = 0;
+  for (int i = 0; i < ndarray; ++i)
+    for (int j = 0; j < dcols[i]; ++j)
+      darray[i][ilocal][j] = 0.0;
+
+  if (molecular != Atom::MOLECULAR) return;
+
+  // add bond topology info
+  // for molecular atom styles, but not atom style template
+
+  if (avec->bonds_allow) {
+    num_bond[ilocal] = onemol->num_bond[iatom];
+    for (int i = 0; i < num_bond[ilocal]; i++) {
+      bond_type[ilocal][i] = onemol->bond_type[iatom][i];
+      bond_atom[ilocal][i] = onemol->bond_atom[iatom][i] + offset;
+    }
+  }
+
+  if (avec->angles_allow) {
+    num_angle[ilocal] = onemol->num_angle[iatom];
+    for (int i = 0; i < num_angle[ilocal]; i++) {
+      angle_type[ilocal][i] = onemol->angle_type[iatom][i];
+      angle_atom1[ilocal][i] = onemol->angle_atom1[iatom][i] + offset;
+      angle_atom2[ilocal][i] = onemol->angle_atom2[iatom][i] + offset;
+      angle_atom3[ilocal][i] = onemol->angle_atom3[iatom][i] + offset;
+    }
+  }
+
+  if (avec->dihedrals_allow) {
+    num_dihedral[ilocal] = onemol->num_dihedral[iatom];
+    for (int i = 0; i < num_dihedral[ilocal]; i++) {
+      dihedral_type[ilocal][i] = onemol->dihedral_type[iatom][i];
+      dihedral_atom1[ilocal][i] = onemol->dihedral_atom1[iatom][i] + offset;
+      dihedral_atom2[ilocal][i] = onemol->dihedral_atom2[iatom][i] + offset;
+      dihedral_atom3[ilocal][i] = onemol->dihedral_atom3[iatom][i] + offset;
+      dihedral_atom4[ilocal][i] = onemol->dihedral_atom4[iatom][i] + offset;
+    }
+  }
+
+  if (avec->impropers_allow) {
+    num_improper[ilocal] = onemol->num_improper[iatom];
+    for (int i = 0; i < num_improper[ilocal]; i++) {
+      improper_type[ilocal][i] = onemol->improper_type[iatom][i];
+      improper_atom1[ilocal][i] = onemol->improper_atom1[iatom][i] + offset;
+      improper_atom2[ilocal][i] = onemol->improper_atom2[iatom][i] + offset;
+      improper_atom3[ilocal][i] = onemol->improper_atom3[iatom][i] + offset;
+      improper_atom4[ilocal][i] = onemol->improper_atom4[iatom][i] + offset;
+    }
+  }
+
+  if (onemol->specialflag) {
+    nspecial[ilocal][0] = onemol->nspecial[iatom][0];
+    nspecial[ilocal][1] = onemol->nspecial[iatom][1];
+    int n = nspecial[ilocal][2] = onemol->nspecial[iatom][2];
+    for (int i = 0; i < n; i++)
+      special[ilocal][i] = onemol->special[iatom][i] + offset;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   reorder owned atoms so those in firstgroup appear first
+   called by comm->exchange() if atom_modify first group is set
+   only owned atoms exist at this point, no ghost atoms
+------------------------------------------------------------------------- */
+
+void Atom::first_reorder()
+{
+  // insure there is one extra atom location at end of arrays for swaps
+
+  if (nlocal == nmax) avec->grow(0);
+
+  // loop over owned atoms
+  // nfirst = index of first atom not in firstgroup
+  // when find firstgroup atom out of place, swap it with atom nfirst
+
+  int bitmask = group->bitmask[firstgroup];
+  nfirst = 0;
+  while (nfirst < nlocal && mask[nfirst] & bitmask) nfirst++;
+
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & bitmask && i > nfirst) {
+      avec->copy(i,nlocal,0);
+      avec->copy(nfirst,i,0);
+      avec->copy(nlocal,nfirst,0);
+      while (nfirst < nlocal && mask[nfirst] & bitmask) nfirst++;
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   perform spatial sort of atoms within my sub-domain
+   always called between comm->exchange() and comm->borders()
+   don't have to worry about clearing/setting atom->map since done in comm
+------------------------------------------------------------------------- */
+
+void Atom::sort()
+{
+  int i,m,n,ix,iy,iz,ibin,empty;
+
+  // set next timestep for sorting to take place
+
+  nextsort = (update->ntimestep/sortfreq)*sortfreq + sortfreq;
+
+  // re-setup sort bins if needed
+
+  if (domain->box_change) setup_sort_bins();
+  if (nbins == 1) return;
+
+  // reallocate per-atom vectors if needed
+
+  if (nlocal > maxnext) {
+    memory->destroy(next);
+    memory->destroy(permute);
+    maxnext = atom->nmax;
+    memory->create(next,maxnext,"atom:next");
+    memory->create(permute,maxnext,"atom:permute");
+  }
+
+  // insure there is one extra atom location at end of arrays for swaps
+
+  if (nlocal == nmax) avec->grow(0);
+
+  // bin atoms in reverse order so linked list will be in forward order
+
+  for (i = 0; i < nbins; i++) binhead[i] = -1;
+
+  for (i = nlocal-1; i >= 0; i--) {
+    ix = static_cast<int> ((x[i][0]-bboxlo[0])*bininvx);
+    iy = static_cast<int> ((x[i][1]-bboxlo[1])*bininvy);
+    iz = static_cast<int> ((x[i][2]-bboxlo[2])*bininvz);
+    ix = MAX(ix,0);
+    iy = MAX(iy,0);
+    iz = MAX(iz,0);
+    ix = MIN(ix,nbinx-1);
+    iy = MIN(iy,nbiny-1);
+    iz = MIN(iz,nbinz-1);
+    ibin = iz*nbiny*nbinx + iy*nbinx + ix;
+    next[i] = binhead[ibin];
+    binhead[ibin] = i;
+  }
+
+  // permute = desired permutation of atoms
+  // permute[I] = J means Ith new atom will be Jth old atom
+
+  n = 0;
+  for (m = 0; m < nbins; m++) {
+    i = binhead[m];
+    while (i >= 0) {
+      permute[n++] = i;
+      i = next[i];
+    }
+  }
+
+  // current = current permutation, just reuse next vector
+  // current[I] = J means Ith current atom is Jth old atom
+
+  int *current = next;
+  for (i = 0; i < nlocal; i++) current[i] = i;
+
+  // reorder local atom list, when done, current = permute
+  // perform "in place" using copy() to extra atom location at end of list
+  // inner while loop processes one cycle of the permutation
+  // copy before inner-loop moves an atom to end of atom list
+  // copy after inner-loop moves atom at end of list back into list
+  // empty = location in atom list that is currently empty
+
+  for (i = 0; i < nlocal; i++) {
+    if (current[i] == permute[i]) continue;
+    avec->copy(i,nlocal,0);
+    empty = i;
+    while (permute[empty] != i) {
+      avec->copy(permute[empty],empty,0);
+      empty = current[empty] = permute[empty];
+    }
+    avec->copy(nlocal,empty,0);
+    current[empty] = permute[empty];
+  }
+
+  // sanity check that current = permute
+
+  //int flag = 0;
+  //for (i = 0; i < nlocal; i++)
+  //  if (current[i] != permute[i]) flag = 1;
+  //int flagall;
+  //MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
+  //if (flagall) error->all(FLERR,"Atom sort did not operate correctly");
+}
+
+/* ----------------------------------------------------------------------
+   setup bins for spatial sorting of atoms
+------------------------------------------------------------------------- */
+
+void Atom::setup_sort_bins()
+{
+  // binsize:
+  // user setting if explicitly set
+  // default = 1/2 of neighbor cutoff
+  // check if neighbor cutoff = 0.0
+  // and in that case, disable sorting
+
+  double binsize = 0.0;
+  if (userbinsize > 0.0) binsize = userbinsize;
+  else if (neighbor->cutneighmax > 0.0) binsize = 0.5 * neighbor->cutneighmax;
+
+  if ((binsize == 0.0) && (sortfreq > 0)) {
+    sortfreq = 0;
+    if (comm->me == 0)
+      error->warning(FLERR,"No pairwise cutoff or binsize set. Atom sorting therefore disabled.");
+    return;
+  }
+
+  double bininv = 1.0/binsize;
+
+  // nbin xyz = local bins
+  // bbox lo/hi = bounding box of my sub-domain
+
+  if (domain->triclinic)
+    domain->bbox(domain->sublo_lamda,domain->subhi_lamda,bboxlo,bboxhi);
+  else {
+    bboxlo[0] = domain->sublo[0];
+    bboxlo[1] = domain->sublo[1];
+    bboxlo[2] = domain->sublo[2];
+    bboxhi[0] = domain->subhi[0];
+    bboxhi[1] = domain->subhi[1];
+    bboxhi[2] = domain->subhi[2];
+  }
+
+  nbinx = static_cast<int> ((bboxhi[0]-bboxlo[0]) * bininv);
+  nbiny = static_cast<int> ((bboxhi[1]-bboxlo[1]) * bininv);
+  nbinz = static_cast<int> ((bboxhi[2]-bboxlo[2]) * bininv);
+  if (domain->dimension == 2) nbinz = 1;
+
+  if (nbinx == 0) nbinx = 1;
+  if (nbiny == 0) nbiny = 1;
+  if (nbinz == 0) nbinz = 1;
+
+  bininvx = nbinx / (bboxhi[0]-bboxlo[0]);
+  bininvy = nbiny / (bboxhi[1]-bboxlo[1]);
+  bininvz = nbinz / (bboxhi[2]-bboxlo[2]);
+
+#ifdef LMP_INTEL
+  if (neighbor->has_intel_request() && userbinsize == 0.0) {
+    if (neighbor->binsizeflag) bininv = 1.0/neighbor->binsize_user;
+
+    double nx_low = neighbor->bboxlo[0];
+    double ny_low = neighbor->bboxlo[1];
+    double nz_low = neighbor->bboxlo[2];
+    double nxbbox = neighbor->bboxhi[0] - nx_low;
+    double nybbox = neighbor->bboxhi[1] - ny_low;
+    double nzbbox = neighbor->bboxhi[2] - nz_low;
+    int nnbinx = static_cast<int> (nxbbox * bininv);
+    int nnbiny = static_cast<int> (nybbox * bininv);
+    int nnbinz = static_cast<int> (nzbbox * bininv);
+    if (domain->dimension == 2) nnbinz = 1;
+
+    if (nnbinx == 0) nnbinx = 1;
+    if (nnbiny == 0) nnbiny = 1;
+    if (nnbinz == 0) nnbinz = 1;
+
+    double binsizex = nxbbox/nnbinx;
+    double binsizey = nybbox/nnbiny;
+    double binsizez = nzbbox/nnbinz;
+
+    bininvx = 1.0 / binsizex;
+    bininvy = 1.0 / binsizey;
+    bininvz = 1.0 / binsizez;
+
+    int lxo = (bboxlo[0] - nx_low) * bininvx;
+    int lyo = (bboxlo[1] - ny_low) * bininvy;
+    int lzo = (bboxlo[2] - nz_low) * bininvz;
+    bboxlo[0] = nx_low + static_cast<double>(lxo) / bininvx;
+    bboxlo[1] = ny_low + static_cast<double>(lyo) / bininvy;
+    bboxlo[2] = nz_low + static_cast<double>(lzo) / bininvz;
+    nbinx = static_cast<int>((bboxhi[0] - bboxlo[0]) * bininvx) + 1;
+    nbiny = static_cast<int>((bboxhi[1] - bboxlo[1]) * bininvy) + 1;
+    nbinz = static_cast<int>((bboxhi[2] - bboxlo[2]) * bininvz) + 1;
+    bboxhi[0] = bboxlo[0] + static_cast<double>(nbinx) / bininvx;
+    bboxhi[1] = bboxlo[1] + static_cast<double>(nbiny) / bininvy;
+    bboxhi[2] = bboxlo[2] + static_cast<double>(nbinz) / bininvz;
+  }
+#endif
+
+#ifdef LMP_GPU
+  if (userbinsize == 0.0) {
+    FixGPU *fix = dynamic_cast<FixGPU *>(modify->get_fix_by_id("package_gpu"));
+    if (fix) {
+      const double subx = domain->subhi[0] - domain->sublo[0];
+      const double suby = domain->subhi[1] - domain->sublo[1];
+      const double subz = domain->subhi[2] - domain->sublo[2];
+
+      binsize = fix->binsize(subx, suby, subz, atom->nlocal,neighbor->cutneighmax);
+      bininv = 1.0 / binsize;
+
+      nbinx = static_cast<int> (ceil(subx * bininv));
+      nbiny = static_cast<int> (ceil(suby * bininv));
+      nbinz = static_cast<int> (ceil(subz * bininv));
+      if (domain->dimension == 2) nbinz = 1;
+
+      if (nbinx == 0) nbinx = 1;
+      if (nbiny == 0) nbiny = 1;
+      if (nbinz == 0) nbinz = 1;
+
+      bininvx = bininv;
+      bininvy = bininv;
+      bininvz = bininv;
+    }
+  }
+#endif
+
+  if (1.0*nbinx*nbiny*nbinz > INT_MAX) error->one(FLERR,"Too many atom sorting bins");
+
+  nbins = nbinx*nbiny*nbinz;
+
+  // reallocate per-bin memory if needed
+
+  if (nbins > maxbin) {
+    memory->destroy(binhead);
+    maxbin = nbins;
+    memory->create(binhead,maxbin,"atom:binhead");
+  }
+}
+
+/* ----------------------------------------------------------------------
+   register a callback to a fix so it can manage atom-based arrays
+   happens when fix is created
+   flag = 0 for grow, 1 for restart, 2 for border comm
+------------------------------------------------------------------------- */
+
+void Atom::add_callback(int flag)
+{
+  int ifix;
+
+  // find the fix
+  // if find null pointer:
+  //   it's this one, since it is being replaced and has just been deleted
+  //   at this point in re-creation
+  // if don't find null pointer:
+  //   i is set to nfix = new one currently being added at end of list
+
+  for (ifix = 0; ifix < modify->nfix; ifix++)
+    if (modify->fix[ifix] == nullptr) break;
+
+  // add callback to lists and sort, reallocating if necessary
+  // sorting is required in cases where fixes were replaced as it ensures atom
+  // data is read/written/transfered in the same order that fixes are called
+
+  if (flag == GROW) {
+    if (nextra_grow == nextra_grow_max) {
+      nextra_grow_max += DELTA;
+      memory->grow(extra_grow,nextra_grow_max,"atom:extra_grow");
+    }
+    extra_grow[nextra_grow] = ifix;
+    nextra_grow++;
+    std::sort(extra_grow, extra_grow + nextra_grow);
+  } else if (flag == RESTART) {
+    if (nextra_restart == nextra_restart_max) {
+      nextra_restart_max += DELTA;
+      memory->grow(extra_restart,nextra_restart_max,"atom:extra_restart");
+    }
+    extra_restart[nextra_restart] = ifix;
+    nextra_restart++;
+    std::sort(extra_restart, extra_restart + nextra_restart);
+  } else if (flag == BORDER) {
+    if (nextra_border == nextra_border_max) {
+      nextra_border_max += DELTA;
+      memory->grow(extra_border,nextra_border_max,"atom:extra_border");
+    }
+    extra_border[nextra_border] = ifix;
+    nextra_border++;
+    std::sort(extra_border, extra_border + nextra_border);
+  }
+}
+
+/* ----------------------------------------------------------------------
+   unregister a callback to a fix
+   happens when fix is deleted, called by its destructor
+   flag = 0 for grow, 1 for restart
+------------------------------------------------------------------------- */
+
+void Atom::delete_callback(const char *id, int flag)
+{
+  if (id == nullptr) return;
+
+  int ifix = modify->find_fix(id);
+
+  // compact the list of callbacks
+
+  if (flag == GROW) {
+    int match;
+    for (match = 0; match < nextra_grow; match++)
+      if (extra_grow[match] == ifix) break;
+    if ((nextra_grow == 0) || (match == nextra_grow))
+      error->all(FLERR,"Trying to delete non-existent Atom::grow() callback");
+    for (int i = match; i < nextra_grow-1; i++)
+      extra_grow[i] = extra_grow[i+1];
+    nextra_grow--;
+
+  } else if (flag == RESTART) {
+    int match;
+    for (match = 0; match < nextra_restart; match++)
+      if (extra_restart[match] == ifix) break;
+    if ((nextra_restart == 0) || (match == nextra_restart))
+      error->all(FLERR,"Trying to delete non-existent Atom::restart() callback");
+    for (int i = match; i < nextra_restart-1; i++)
+      extra_restart[i] = extra_restart[i+1];
+    nextra_restart--;
+
+  } else if (flag == BORDER) {
+    int match;
+    for (match = 0; match < nextra_border; match++)
+      if (extra_border[match] == ifix) break;
+    if ((nextra_border == 0) || (match == nextra_border))
+      error->all(FLERR,"Trying to delete non-existent Atom::border() callback");
+    for (int i = match; i < nextra_border-1; i++)
+      extra_border[i] = extra_border[i+1];
+    nextra_border--;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   decrement ptrs in callback lists to fixes beyond the deleted ifix
+   happens after fix is deleted
+------------------------------------------------------------------------- */
+
+void Atom::update_callback(int ifix)
+{
+  for (int i = 0; i < nextra_grow; i++)
+    if (extra_grow[i] > ifix) extra_grow[i]--;
+  for (int i = 0; i < nextra_restart; i++)
+    if (extra_restart[i] > ifix) extra_restart[i]--;
+  for (int i = 0; i < nextra_border; i++)
+    if (extra_border[i] > ifix) extra_border[i]--;
+}
+
+/* ----------------------------------------------------------------------
+   find custom per-atom vector with name
+   return index if found, -1 if not found
+     lists of names can have NULL entries if previously removed
+   return flag = 0/1 for int/double
+   return cols = 0/N for vector/array where N = # of columns
+------------------------------------------------------------------------- */
+
+int Atom::find_custom(const char *name, int &flag, int &cols)
+{
+  if (name == nullptr) return -1;
+
+  for (int i = 0; i < nivector; i++)
+    if (ivname[i] && strcmp(ivname[i],name) == 0) {
+      flag = 0;
+      cols = 0;
+      return i;
+    }
+
+  for (int i = 0; i < ndvector; i++)
+    if (dvname[i] && strcmp(dvname[i],name) == 0) {
+      flag = 1;
+      cols = 0;
+      return i;
+    }
+
+  for (int i = 0; i < niarray; i++)
+    if (ianame[i] && strcmp(ianame[i],name) == 0) {
+      flag = 0;
+      cols = icols[i];
+      return i;
+    }
+
+  for (int i = 0; i < ndarray; i++)
+    if (daname[i] && strcmp(daname[i],name) == 0) {
+      flag = 1;
+      cols = dcols[i];
+      return i;
+    }
+
+  return -1;
+}
+
+/** \brief Add a custom per-atom property with the given name and type and size
+\verbatim embed:rst
+
+This function will add a custom per-atom property with one or more values
+with the name "name" to the list of custom properties.
+This function is called, e.g. from :doc:`fix property/atom <fix_property_atom>`.
+\endverbatim
+ * \param name Name of the property (w/o a "i_" or "d_" or "i2_" or "d2_" prefix)
+ * \param flag Data type of property: 0 for int, 1 for double
+ * \param cols Number of values: 0 for a single value, 1 or more for a vector of values
+ * \return index of property in the respective list of properties
+ */
+int Atom::add_custom(const char *name, int flag, int cols)
+{
+  int index = -1;
+
+  if ((flag == 0) && (cols == 0)) {
+    index = nivector;
+    nivector++;
+    ivname = (char **) memory->srealloc(ivname,nivector*sizeof(char *),"atom:ivname");
+    ivname[index] = utils::strdup(name);
+    ivector = (int **) memory->srealloc(ivector,nivector*sizeof(int *),"atom:ivector");
+    memory->create(ivector[index],nmax,"atom:ivector");
+
+  } else if ((flag == 1) && (cols == 0)) {
+    index = ndvector;
+    ndvector++;
+    dvname = (char **) memory->srealloc(dvname,ndvector*sizeof(char *),"atom:dvname");
+    dvname[index] = utils::strdup(name);
+    dvector = (double **) memory->srealloc(dvector,ndvector*sizeof(double *),"atom:dvector");
+    memory->create(dvector[index],nmax,"atom:dvector");
+
+  } else if ((flag == 0) && (cols > 0)) {
+    index = niarray;
+    niarray++;
+    ianame = (char **) memory->srealloc(ianame,niarray*sizeof(char *),"atom:ianame");
+    ianame[index] = utils::strdup(name);
+    iarray = (int ***) memory->srealloc(iarray,niarray*sizeof(int **),"atom:iarray");
+    memory->create(iarray[index],nmax,cols,"atom:iarray");
+
+    icols = (int *) memory->srealloc(icols,niarray*sizeof(int),"atom:icols");
+    icols[index] = cols;
+
+  } else if ((flag == 1) && (cols > 0)) {
+    index = ndarray;
+    ndarray++;
+    daname = (char **) memory->srealloc(daname,ndarray*sizeof(char *),"atom:daname");
+    daname[index] = utils::strdup(name);
+    darray = (double ***) memory->srealloc(darray,ndarray*sizeof(double **),"atom:darray");
+    memory->create(darray[index],nmax,cols,"atom:darray");
+
+    dcols = (int *) memory->srealloc(dcols,ndarray*sizeof(int),"atom:dcols");
+    dcols[index] = cols;
+  }
+  if (index < 0)
+    error->all(FLERR,"Invalid call to Atom::add_custom()");
+  return index;
+}
+
+/*! \brief Remove a custom per-atom property of a given type and size
+ *
+\verbatim embed:rst
+This will remove a property that was requested, e.g. by the
+:doc:`fix property/atom <fix_property_atom>` command.  It frees the
+allocated memory and sets the pointer to ``nullptr`` for the entry in
+the list so it can be reused. The lists of these pointers are never
+compacted or shrink, so that indices to name mappings remain valid.
+\endverbatim
+ * \param index Index of property in the respective list of properties
+ * \param flag Data type of property: 0 for int, 1 for double
+ * \param cols Number of values: 0 for a single value, 1 or more for a vector of values
+ */
+void Atom::remove_custom(int index, int flag, int cols)
+{
+  if (flag == 0 && cols == 0) {
+    memory->destroy(ivector[index]);
+    ivector[index] = nullptr;
+    delete[] ivname[index];
+    ivname[index] = nullptr;
+
+  } else if (flag == 1 && cols == 0) {
+    memory->destroy(dvector[index]);
+    dvector[index] = nullptr;
+    delete[] dvname[index];
+    dvname[index] = nullptr;
+
+  } else if (flag == 0 && cols) {
+    memory->destroy(iarray[index]);
+    iarray[index] = nullptr;
+    delete[] ianame[index];
+    ianame[index] = nullptr;
+
+  } else if (flag == 1 && cols) {
+    memory->destroy(darray[index]);
+    darray[index] = nullptr;
+    delete[] daname[index];
+    daname[index] = nullptr;
+  }
+}
+
+/** Provide access to internal data of the Atom class by keyword
+ *
+\verbatim embed:rst
+
+This function is a way to access internal per-atom data.  This data is
+distributed across MPI ranks and thus only the data for "local" atoms
+are expected to be available.  Whether also data for "ghost" atoms is
+stored and up-to-date depends on various simulation settings.
+
+This table lists a large part of the supported names, their data types,
+length of the data area, and a short description.
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Name
+     - Type
+     - Items per atom
+     - Description
+   * - mass
+     - double
+     - 1
+     - per-type mass. This array is **NOT** a per-atom array
+       but of length ``ntypes+1``, element 0 is ignored.
+   * - id
+     - tagint
+     - 1
+     - atom ID of the particles
+   * - type
+     - int
+     - 1
+     - atom type of the particles
+   * - mask
+     - int
+     - 1
+     - bitmask for mapping to groups. Individual bits are set
+       to 0 or 1 for each group.
+   * - image
+     - imageint
+     - 1
+     - 3 image flags encoded into a single integer.
+       See :cpp:func:`lammps_encode_image_flags`.
+   * - x
+     - double
+     - 3
+     - x-, y-, and z-coordinate of the particles
+   * - v
+     - double
+     - 3
+     - x-, y-, and z-component of the velocity of the particles
+   * - f
+     - double
+     - 3
+     - x-, y-, and z-component of the force on the particles
+   * - molecule
+     - int
+     - 1
+     - molecule ID of the particles
+   * - q
+     - double
+     - 1
+     - charge of the particles
+   * - mu
+     - double
+     - 3
+     - dipole moment of the particles
+   * - omega
+     - double
+     - 3
+     - x-, y-, and z-component of rotational velocity of the particles
+   * - angmom
+     - double
+     - 3
+     - x-, y-, and z-component of angular momentum of the particles
+   * - torque
+     - double
+     - 3
+     - x-, y-, and z-component of the torque on the particles
+   * - radius
+     - double
+     - 1
+     - radius of the (extended) particles
+   * - rmass
+     - double
+     - 1
+     - per-atom mass of the particles. ``nullptr`` if per-type masses are
+       used. See the :cpp:func:`rmass_flag<lammps_extract_setting>` setting.
+   * - ellipsoid
+     - int
+     - 1
+     - 1 if the particle is an ellipsoidal particle, 0 if not
+   * - line
+     - int
+     - 1
+     - 1 if the particle is a line particle, 0 if not
+   * - tri
+     - int
+     - 1
+     - 1 if the particle is a triangulated particle, 0 if not
+   * - body
+     - int
+     - 1
+     - 1 if the particle is a body particle, 0 if not
+   * - quat
+     - double
+     - 4
+     - four quaternion components of the particles
+   * - i_name
+     - int
+     - 1
+     - single integer value defined by fix property/atom vector name
+   * - d_name
+     - double
+     - 1
+     - single double value defined by fix property/atom vector name
+   * - i2_name
+     - int
+     - n
+     - N integer values defined by fix property/atom array name
+   * - d2_name
+     - double
+     - n
+     - N double values defined by fix property/atom array name
+
+*See also*
+   :cpp:func:`lammps_extract_atom`
+
+\endverbatim
+ *
+ * \sa extract_datatype
+ *
+ * \param  name  string with the keyword of the desired property.
+                 Typically the name of the pointer variable returned
+ * \return       pointer to the requested data cast to ``void *`` or ``nullptr`` */
+
+void *Atom::extract(const char *name)
+{
+  // --------------------------------------------------------------------
+  // 4th customization section: customize by adding new variable name
+  // if new variable is from a package, add package comment
+
+  if (strcmp(name,"mass") == 0) return (void *) mass;
+
+  if (strcmp(name,"id") == 0) return (void *) tag;
+  if (strcmp(name,"type") == 0) return (void *) type;
+  if (strcmp(name,"mask") == 0) return (void *) mask;
+  if (strcmp(name,"image") == 0) return (void *) image;
+  if (strcmp(name,"x") == 0) return (void *) x;
+  if (strcmp(name,"v") == 0) return (void *) v;
+  if (strcmp(name,"f") == 0) return (void *) f;
+  if (strcmp(name,"molecule") == 0) return (void *) molecule;
+  if (strcmp(name,"q") == 0) return (void *) q;
+  if (strcmp(name,"mu") == 0) return (void *) mu;
+  if (strcmp(name,"omega") == 0) return (void *) omega;
+  if (strcmp(name,"angmom") == 0) return (void *) angmom;
+  if (strcmp(name,"torque") == 0) return (void *) torque;
+  if (strcmp(name,"radius") == 0) return (void *) radius;
+  if (strcmp(name,"rmass") == 0) return (void *) rmass;
+  if (strcmp(name,"ellipsoid") == 0) return (void *) ellipsoid;
+  if (strcmp(name,"line") == 0) return (void *) line;
+  if (strcmp(name,"tri") == 0) return (void *) tri;
+  if (strcmp(name,"body") == 0) return (void *) body;
+  if (strcmp(name,"quat") == 0) return (void *) quat;
+
+  if (strcmp(name,"vfrac") == 0) return (void *) vfrac;
+  if (strcmp(name,"s0") == 0) return (void *) s0;
+  if (strcmp(name,"x0") == 0) return (void *) x0;
+
+  if (strcmp(name,"spin") == 0) return (void *) spin;
+  if (strcmp(name,"eradius") == 0) return (void *) eradius;
+  if (strcmp(name,"ervel") == 0) return (void *) ervel;
+  if (strcmp(name,"erforce") == 0) return (void *) erforce;
+  if (strcmp(name,"ervelforce") == 0) return (void *) ervelforce;
+  if (strcmp(name,"cs") == 0) return (void *) cs;
+  if (strcmp(name,"csforce") == 0) return (void *) csforce;
+  if (strcmp(name,"vforce") == 0) return (void *) vforce;
+  if (strcmp(name,"etag") == 0) return (void *) etag;
+
+  if (strcmp(name,"rho") == 0) return (void *) rho;
+  if (strcmp(name,"drho") == 0) return (void *) drho;
+  if (strcmp(name,"esph") == 0) return (void *) esph;
+  if (strcmp(name,"desph") == 0) return (void *) desph;
+  if (strcmp(name,"cv") == 0) return (void *) cv;
+  if (strcmp(name,"vest") == 0) return (void *) vest;
+
+  // MESONT package
+
+  if (strcmp(name,"length") == 0) return (void *) length;
+  if (strcmp(name,"buckling") == 0) return (void *) buckling;
+  if (strcmp(name,"bond_nt") == 0) return (void *) bond_nt;
+
+  // MACHDYN package
+
+  if (strcmp(name, "contact_radius") == 0) return (void *) contact_radius;
+  if (strcmp(name, "smd_data_9") == 0) return (void *) smd_data_9;
+  if (strcmp(name, "smd_stress") == 0) return (void *) smd_stress;
+  if (strcmp(name, "eff_plastic_strain") == 0)
+    return (void *) eff_plastic_strain;
+  if (strcmp(name, "eff_plastic_strain_rate") == 0)
+    return (void *) eff_plastic_strain_rate;
+  if (strcmp(name, "damage") == 0) return (void *) damage;
+
+  // DPD-REACT pakage
+
+  if (strcmp(name,"dpdTheta") == 0) return (void *) dpdTheta;
+
+  // DPD-MESO package
+
+  if (strcmp(name,"edpd_temp") == 0) return (void *) edpd_temp;
+
+  // DIELECTRIC package
+
+  if (strcmp(name,"area") == 0) return (void *) area;
+  if (strcmp(name,"ed") == 0) return (void *) ed;
+  if (strcmp(name,"em") == 0) return (void *) em;
+  if (strcmp(name,"epsilon") == 0) return (void *) epsilon;
+  if (strcmp(name,"curvature") == 0) return (void *) curvature;
+  if (strcmp(name,"q_unscaled") == 0) return (void *) q_unscaled;
+
+  // AWSEM-MD package
+
+  if (strcmp(name,"residue") == 0) return (void *) residue;
+
+  // end of customization section
+  // --------------------------------------------------------------------
+
+  // custom vectors and arrays
+
+  if (utils::strmatch(name,"^[id]2?_")) {
+    int which = 0, array = 0;
+    if (name[0] == 'd') which = 1;
+    if (name[1] == '2') array = 1;
+
+    int index,flag,cols;
+    if (!array) index = find_custom(&name[2],flag,cols);
+    else index = find_custom(&name[3],flag,cols);
+
+    if (index < 0) return nullptr;
+    if (which != flag) return nullptr;
+    if ((!array && cols) || (array && !cols)) return nullptr;
+
+    if (!which && !array) return (void *) ivector[index];
+    if (which && !array) return (void *) dvector[index];
+    if (!which && array) return (void *) iarray[index];
+    if (which && array) return (void *) darray[index];
+  }
+
+  return nullptr;
+}
+
+/** Provide data type info about internal data of the Atom class
+ *
+\verbatim embed:rst
+
+.. versionadded:: 18Sep2020
+
+\endverbatim
+ *
+ * \sa extract
+ *
+ * \param  name  string with the keyword of the desired property.
+ * \return       data type constant for desired property or -1 */
+
+int Atom::extract_datatype(const char *name)
+{
+  // --------------------------------------------------------------------
+  // 5th customization section: customize by adding new variable name
+
+  if (strcmp(name,"mass") == 0) return LAMMPS_DOUBLE;
+
+  if (strcmp(name,"id") == 0) return LAMMPS_TAGINT;
+  if (strcmp(name,"type") == 0) return LAMMPS_INT;
+  if (strcmp(name,"mask") == 0) return LAMMPS_INT;
+  if (strcmp(name,"image") == 0) return LAMMPS_TAGINT;
+  if (strcmp(name,"x") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"v") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"f") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"molecule") == 0) return LAMMPS_TAGINT;
+  if (strcmp(name,"q") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"mu") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"omega") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"angmom") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"torque") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"radius") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"rmass") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"ellipsoid") == 0) return LAMMPS_INT;
+  if (strcmp(name,"line") == 0) return LAMMPS_INT;
+  if (strcmp(name,"tri") == 0) return LAMMPS_INT;
+  if (strcmp(name,"body") == 0) return LAMMPS_INT;
+  if (strcmp(name,"quat") == 0) return LAMMPS_DOUBLE_2D;
+
+  if (strcmp(name,"vfrac") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"s0") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"x0") == 0) return LAMMPS_DOUBLE_2D;
+
+  if (strcmp(name,"spin") == 0) return LAMMPS_INT;
+  if (strcmp(name,"eradius") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"ervel") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"erforce") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"ervelforce") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"cs") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"csforce") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"vforce") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name,"etag") == 0) return LAMMPS_INT;
+
+  if (strcmp(name,"rho") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"drho") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"esph") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"desph") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"cv") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"vest") == 0) return LAMMPS_DOUBLE_2D;
+
+  // MESONT package
+
+  if (strcmp(name,"length") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"buckling") == 0) return LAMMPS_INT;
+  if (strcmp(name,"bond_nt") == 0) return  LAMMPS_TAGINT_2D;
+
+  // MACHDYN package
+
+  if (strcmp(name, "contact_radius") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name, "smd_data_9") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name, "smd_stress") == 0) return LAMMPS_DOUBLE_2D;
+  if (strcmp(name, "eff_plastic_strain") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name, "eff_plastic_strain_rate") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name, "damage") == 0) return LAMMPS_DOUBLE;
+
+  // DPD-REACT package
+
+  if (strcmp(name,"dpdTheta") == 0) return LAMMPS_DOUBLE;
+
+  // DPD-MESO package
+
+  if (strcmp(name,"edpd_temp") == 0) return LAMMPS_DOUBLE;
+
+  // DIELECTRIC package
+
+  if (strcmp(name,"area") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"ed") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"em") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"epsilon") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"curvature") == 0) return LAMMPS_DOUBLE;
+  if (strcmp(name,"q_unscaled") == 0) return LAMMPS_DOUBLE;
+
+  // AWSEM-MD package
+
+  if (strcmp(name,"residue") == 0) return LAMMPS_TAGINT;
+
+  // end of customization section
+  // --------------------------------------------------------------------
+
+  // custom vectors and arrays
+
+  if (utils::strmatch(name,"^[id]2?_")) {
+    int which = 0, array = 0;
+    if (name[0] == 'd') which = 1;
+    if (name[1] == '2') array = 1;
+
+    int index,flag,cols;
+    if (!array) index = find_custom(&name[2],flag,cols);
+    else index = find_custom(&name[3],flag,cols);
+
+    if (index < 0) return -1;
+    if (which != flag) return -1;
+    if ((!array && cols) || (array && !cols)) return -1;
+
+    if (which == 0) return LAMMPS_INT;
+    else return LAMMPS_DOUBLE;
+  }
+
+  return -1;
+}
+
+/* ----------------------------------------------------------------------
+   return # of bytes of allocated memory
+   call to avec tallies per-atom vectors
+   add in global to local mapping storage
+------------------------------------------------------------------------- */
+
+double Atom::memory_usage()
+{
+  double bytes = avec->memory_usage();
+
+  bytes += (double)max_same*sizeof(int);
+  if (map_style == MAP_ARRAY)
+    bytes += memory->usage(map_array,map_maxarray);
+  else if (map_style == MAP_HASH) {
+    bytes += (double)map_nbucket*sizeof(int);
+    bytes += (double)map_nhash*sizeof(HashElem);
+  }
+  if (maxnext) {
+    bytes += memory->usage(next,maxnext);
+    bytes += memory->usage(permute,maxnext);
+  }
+
+  return bytes;
+}

--- a/src/atom.h
+++ b/src/atom.h
@@ -1,0 +1,432 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_ATOM_H
+#define LMP_ATOM_H
+
+#include "pointers.h"
+
+#include <map>
+#include <set>
+
+namespace LAMMPS_NS {
+
+// forward declaration
+
+class AtomVec;
+
+class Atom : protected Pointers {
+ public:
+  char *atom_style;
+  AtomVec *avec;
+  enum { DOUBLE, INT, BIGINT };
+  enum { GROW = 0, RESTART = 1, BORDER = 2 };
+  enum { ATOMIC = 0, MOLECULAR = 1, TEMPLATE = 2 };
+  enum { MAP_NONE = 0, MAP_ARRAY = 1, MAP_HASH = 2, MAP_YES = 3 };
+
+  // atom counts
+
+  bigint natoms;         // total # of atoms in system, could be 0
+                         // natoms may not be current if atoms lost
+  int nlocal, nghost;    // # of owned and ghost atoms on this proc
+  int nmax;              // max # of owned+ghost in arrays on this proc
+  int tag_enable;        // 0/1 if atom ID tags are defined
+  int molecular;         // 0 = atomic, 1 = standard molecular system,
+                         // 2 = molecule template system
+  bigint nellipsoids;    // number of ellipsoids
+  bigint nlines;         // number of lines
+  bigint ntris;          // number of triangles
+  bigint nbodies;        // number of bodies
+
+  // system properties
+
+  bigint nbonds, nangles, ndihedrals, nimpropers;
+  int ntypes, nbondtypes, nangletypes, ndihedraltypes, nimpropertypes;
+  int bond_per_atom, angle_per_atom, dihedral_per_atom, improper_per_atom;
+  int extra_bond_per_atom, extra_angle_per_atom;
+  int extra_dihedral_per_atom, extra_improper_per_atom;
+
+  int firstgroup;          // store atoms in this group first, -1 if unset
+  int nfirst;              // # of atoms in first group on this proc
+  char *firstgroupname;    // group-ID to store first, null pointer if unset
+
+  // --------------------------------------------------------------------
+  // 1st customization section: customize by adding new per-atom variable
+  // per-atom vectors and arrays
+
+  tagint *tag;
+  int *type, *mask;
+  imageint *image;
+  double **x, **v, **f;
+
+  // charged and dipolar particles
+
+  double *rmass;
+  double *q, **mu;
+
+  // finite-size particles
+
+  double *radius;
+  double **omega, **angmom, **torque;
+  int *ellipsoid, *line, *tri, *body;
+  double **quat;
+
+  // molecular systems
+
+  tagint *molecule;
+  int *molindex, *molatom;
+
+  int **nspecial;      // 0,1,2 = cumulative # of 1-2,1-3,1-4 neighs
+  tagint **special;    // IDs of 1-2,1-3,1-4 neighs of each atom
+  int maxspecial;      // special[nlocal][maxspecial]
+
+  int *num_bond;
+  int **bond_type;
+  tagint **bond_atom;
+
+  int *num_angle;
+  int **angle_type;
+  tagint **angle_atom1, **angle_atom2, **angle_atom3;
+
+  int *num_dihedral;
+  int **dihedral_type;
+  tagint **dihedral_atom1, **dihedral_atom2, **dihedral_atom3, **dihedral_atom4;
+
+  int *num_improper;
+  int **improper_type;
+  tagint **improper_atom1, **improper_atom2, **improper_atom3, **improper_atom4;
+
+  // PERI package
+
+  double *vfrac, *s0;
+  double **x0;
+
+  // SPIN package
+
+  double **sp, **fm, **fm_long;
+
+  // EFF and AWPMD packages
+
+  int *spin;
+  double *eradius, *ervel, *erforce;
+  double *ervelforce;
+  double **cs, **csforce, **vforce;
+  int *etag;
+
+  // CG-DNA package
+
+  tagint *id5p;
+
+  // DPD-REACT package
+
+  double *uCond, *uMech, *uChem, *uCGnew, *uCG;
+  double *duChem;
+  double *dpdTheta;
+  int nspecies_dpd;
+
+  // MESO package
+
+  double **cc, **cc_flux;           // cc = chemical concentration
+  double *edpd_temp, *edpd_flux;    // temperature and heat flux
+  double *vest_temp;
+  double *edpd_cv;    // heat capacity
+  int cc_species;
+
+  // MESONT package
+
+  double *length;
+  int *buckling;
+  tagint **bond_nt;
+
+  // MACHDYN package
+
+  double *contact_radius;
+  double **smd_data_9;
+  double **smd_stress;
+  double *eff_plastic_strain;
+  double *eff_plastic_strain_rate;
+  double *damage;
+
+  // SPH package
+
+  double *rho, *drho, *esph, *desph, *cv;
+  double **vest;
+
+  // DIELECTRIC package
+
+  double *area, *ed, *em, *epsilon, *curvature, *q_unscaled;
+
+  // AWSEM-MD package
+
+  tagint *residue;
+
+  // end of customization section
+  // --------------------------------------------------------------------
+
+  // --------------------------------------------------------------------
+  // 2nd customization section: customize by adding new flags
+  // identical list as Atom::set_atomflag_defaults()
+  // most are existence flags for per-atom vectors and arrays
+  // 1 if variable is used, 0 if not
+
+  int sphere_flag, ellipsoid_flag, line_flag, tri_flag, body_flag;
+  int peri_flag, electron_flag;
+  int wavepacket_flag, sph_flag;
+
+  int molecule_flag, molindex_flag, molatom_flag;
+  int q_flag, mu_flag;
+  int rmass_flag, radius_flag, omega_flag, torque_flag, angmom_flag, quat_flag;
+  int vfrac_flag, spin_flag, eradius_flag, ervel_flag, erforce_flag;
+  int cs_flag, csforce_flag, vforce_flag, ervelforce_flag, etag_flag;
+  int rho_flag, esph_flag, cv_flag, vest_flag;
+  int dpd_flag, edpd_flag, tdpd_flag;
+  int mesont_flag;
+  int residue_flag;
+
+  // SPIN package
+
+  int sp_flag;
+
+  // MACHDYN package
+
+  int x0_flag;
+  int smd_flag, damage_flag;
+  int contact_radius_flag, smd_data_9_flag, smd_stress_flag;
+  int eff_plastic_strain_flag, eff_plastic_strain_rate_flag;
+
+  // Peridynamics scale factor, used by dump cfg
+
+  double pdscale;
+
+  // DIELECTRIC package
+
+  int dielectric_flag;
+
+  // end of customization section
+  // --------------------------------------------------------------------
+
+  // per-atom data struct describing all per-atom vectors/arrays
+
+  struct PerAtom {
+    std::string name;
+    void *address;
+    void *address_length;
+    int *address_maxcols;
+    int datatype;
+    int cols;
+    int collength;
+    int threadflag;
+  };
+
+  std::vector<PerAtom> peratom;
+
+  // custom vectors and arrays used by fix property/atom
+
+  int **ivector, ***iarray;
+  double **dvector, ***darray;
+  int *icols, *dcols;
+  char **ivname, **dvname, **ianame, **daname;
+  int nivector, ndvector, niarray, ndarray;
+
+  // molecule templates
+  // each template can be a set of consecutive molecules
+  // each with same ID (stored in molecules)
+  // 1st molecule in template stores nset = # in set
+
+  int nmolecule;
+  class Molecule **molecules;
+
+  // extra peratom info in restart file destined for fix & diag
+
+  double **extra;
+
+  // per-type arrays
+
+  double *mass;
+  int *mass_setflag;
+
+  // callback ptrs for atom arrays managed by fix classes
+
+  int nextra_grow, nextra_restart, nextra_border;    // # of callbacks of each type
+  int *extra_grow, *extra_restart, *extra_border;    // index of fix to callback to
+  int nextra_grow_max, nextra_restart_max;           // size of callback lists
+  int nextra_border_max;
+  int nextra_store;
+
+  int map_style;                    // style of atom map: 0=none, 1=array, 2=hash
+  int map_user;                     // user requested map style:
+                                    // 0 = no request, 1=array, 2=hash, 3=yes
+  tagint map_tag_max;               // max atom ID that map() is setup for
+  std::set<tagint> *unique_tags;    // set to ensure that bodies have unique tags
+
+  // spatial sorting of atoms
+
+  int sortfreq;          // sort atoms every this many steps, 0 = off
+  bigint nextsort;       // next timestep to sort on
+  double userbinsize;    // requested sort bin size
+
+  // indices of atoms with same ID
+
+  int *sametag;    // sametag[I] = next atom with same ID, -1 if no more
+
+  // true if image flags were reset to 0 during data_atoms()
+
+  bool reset_image_flag[3];
+
+  // AtomVec factory types and map
+
+  typedef AtomVec *(*AtomVecCreator)(LAMMPS *);
+  typedef std::map<std::string, AtomVecCreator> AtomVecCreatorMap;
+  AtomVecCreatorMap *avec_map;
+
+  // --------------------------------------------------------------------
+  // functions
+
+  Atom(class LAMMPS *);
+  ~Atom() override;
+
+  void settings(class Atom *);
+  void peratom_create();
+  void add_peratom(const std::string &, void *, int, int, int threadflag = 0);
+  void add_peratom_change_columns(const std::string &, int);
+  void add_peratom_vary(const std::string &, void *, int, int *, void *, int collength = 0);
+  void create_avec(const std::string &, int, char **, int);
+  virtual AtomVec *new_avec(const std::string &, int, int &);
+
+  void init();
+  void setup();
+
+  AtomVec *style_match(const char *);
+  void modify_params(int, char **);
+  void tag_check();
+  void tag_extend();
+  int tag_consecutive();
+
+  void bonus_check();
+
+  int parse_data(const char *);
+
+  void deallocate_topology();
+
+  void data_atoms(int, char *, tagint, tagint, int, int, double *);
+  void data_vels(int, char *, tagint);
+  void data_bonds(int, char *, int *, tagint, int);
+  void data_angles(int, char *, int *, tagint, int);
+  void data_dihedrals(int, char *, int *, tagint, int);
+  void data_impropers(int, char *, int *, tagint, int);
+  void data_bonus(int, char *, AtomVec *, tagint);
+  void data_bodies(int, char *, AtomVec *, tagint);
+  void data_fix_compute_variable(int, int);
+
+  virtual void allocate_type_arrays();
+  void set_mass(const char *, int, const char *, int);
+  void set_mass(const char *, int, int, double);
+  void set_mass(const char *, int, int, char **);
+  void set_mass(double *);
+  void check_mass(const char *, int);
+
+  int radius_consistency(int, double &);
+  int shape_consistency(int, double &, double &, double &);
+
+  void add_molecule(int, char **);
+  int find_molecule(char *);
+  void add_molecule_atom(class Molecule *, int, int, tagint);
+
+  void first_reorder();
+  virtual void sort();
+
+  void add_callback(int);
+  void delete_callback(const char *, int);
+  void update_callback(int);
+
+  int find_custom(const char *, int &, int &);
+  virtual int add_custom(const char *, int, int);
+  virtual void remove_custom(int, int, int);
+
+  virtual void sync_modify(ExecutionSpace, unsigned int, unsigned int) {}
+
+  void *extract(const char *);
+  int extract_datatype(const char *);
+
+  inline int *get_map_array() { return map_array; };
+  inline int get_map_size() { return map_tag_max + 1; };
+  inline int get_max_same() { return max_same; };
+  inline int get_map_maxarray() { return map_maxarray + 1; };
+
+  // NOTE: placeholder method until KOKKOS/AtomVec is refactored
+  int memcheck(const char *) { return 1; }
+
+  double memory_usage();
+
+  // functions for global to local ID mapping
+  // map lookup function inlined for efficiency
+  // return -1 if no map defined
+
+  inline int map(tagint global)
+  {
+    if (map_style == 1)
+      return map_array[global];
+    else if (map_style == 2)
+      return map_find_hash(global);
+    else
+      return -1;
+  };
+
+  virtual void map_init(int check = 1);
+  virtual void map_clear();
+  virtual void map_set();
+  void map_one(tagint, int);
+  int map_style_set();
+  virtual void map_delete();
+  int map_find_hash(tagint);
+
+ protected:
+  // global to local ID mapping
+
+  int *map_array;      // direct map via array that holds map_tag_max
+  int map_maxarray;    // allocated size of map_array (1 larger than this)
+
+  struct HashElem {    // hashed map
+    tagint global;     // key to search on = global ID
+    int local;         // value associated with key = local index
+    int next;          // next entry in this bucket, -1 if last
+  };
+  int map_nhash;         // # of entries hash table can hold
+  int map_nused;         // # of actual entries in hash table
+  int map_free;          // ptr to 1st unused entry in hash table
+  int map_nbucket;       // # of hash buckets
+  int *map_bucket;       // ptr to 1st entry in each bucket
+  HashElem *map_hash;    // hash table
+
+  int max_same;    // allocated size of sametag
+
+  // spatial sorting of atoms
+
+  int nbins;                           // # of sorting bins
+  int nbinx, nbiny, nbinz;             // bins in each dimension
+  int maxbin;                          // max # of bins
+  int maxnext;                         // max size of next,permute
+  int *binhead;                        // 1st atom in each bin
+  int *next;                           // next atom in bin
+  int *permute;                        // permutation vector
+  double bininvx, bininvy, bininvz;    // inverse actual bin sizes
+  double bboxlo[3], bboxhi[3];         // bounding box of my sub-domain
+
+  void set_atomflag_defaults();
+  void setup_sort_bins();
+  int next_prime(int);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif

--- a/src/atom_vec_awsemmd.cpp
+++ b/src/atom_vec_awsemmd.cpp
@@ -1,7 +1,7 @@
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   http://lammps.sandia.gov, Sandia National Laboratories
-   Steve Plimpton, sjplimp@sandia.gov
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
@@ -11,15 +11,8 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#include <stdlib.h>
 #include "atom_vec_awsemmd.h"
 #include "atom.h"
-#include "comm.h"
-#include "domain.h"
-#include "modify.h"
-#include "fix.h"
-#include "memory.h"
-#include "error.h"
 
 using namespace LAMMPS_NS;
 
@@ -27,1103 +20,200 @@ using namespace LAMMPS_NS;
 
 AtomVecAWSEM::AtomVecAWSEM(LAMMPS *lmp) : AtomVec(lmp)
 {
-  molecular = 1;
+  molecular = Atom::MOLECULAR;
   bonds_allow = angles_allow = dihedrals_allow = impropers_allow = 1;
-  mass_type = 1;
+  mass_type = PER_TYPE;
 
-  comm_x_only = comm_f_only = 1;
-  size_forward = 3;
-  size_reverse = 3;
-  size_border = 9;
-  size_velocity = 3;
-  size_data_atom = 8;
-  size_data_vel = 4;
-  xcol_data = 6;
+  atom->molecule_flag = atom->residue_flag = atom->q_flag = 1;
 
-  atom->molecule_flag = atom->q_flag = 1;
-}
+  // strings with peratom variables to include in each AtomVec method
+  // strings cannot contain fields in corresponding AtomVec default strings
+  // order of fields in a string does not matter
+  // except: fields_data_atom & fields_data_vel must match data file
 
-/* ----------------------------------------------------------------------
-   grow atom arrays
-   n = 0 grows arrays by a chunk
-   n > 0 allocates arrays to size n
-------------------------------------------------------------------------- */
+  // clang-format off
+  fields_grow = {"q", "molecule", "residue", "num_bond", "bond_type", "bond_atom", "num_angle", "angle_type",
+    "angle_atom1", "angle_atom2", "angle_atom3", "num_dihedral", "dihedral_type", "dihedral_atom1",
+    "dihedral_atom2", "dihedral_atom3", "dihedral_atom4", "num_improper", "improper_type",
+    "improper_atom1", "improper_atom2", "improper_atom3", "improper_atom4", "nspecial", "special"};
+  fields_copy = {"q", "molecule", "residue", "num_bond", "bond_type", "bond_atom", "num_angle", "angle_type",
+    "angle_atom1", "angle_atom2", "angle_atom3", "num_dihedral", "dihedral_type", "dihedral_atom1",
+    "dihedral_atom2", "dihedral_atom3", "dihedral_atom4", "num_improper", "improper_type",
+    "improper_atom1", "improper_atom2", "improper_atom3", "improper_atom4", "nspecial", "special"};
+  fields_border = {"q", "molecule", "residue"};
+  fields_border_vel = {"q", "molecule", "residue"};
+  fields_exchange = {"q", "molecule", "residue", "num_bond", "bond_type", "bond_atom",
+    "num_angle", "angle_type", "angle_atom1", "angle_atom2", "angle_atom3",
+    "num_dihedral", "dihedral_type", "dihedral_atom1", "dihedral_atom2",
+    "dihedral_atom3", "dihedral_atom4", "num_improper", "improper_type", "improper_atom1",
+    "improper_atom2", "improper_atom3", "improper_atom4", "nspecial", "special"};
+ fields_restart = {"q", "molecule", "residue", "num_bond", "bond_type", "bond_atom", "num_angle",
+   "angle_type", "angle_atom1", "angle_atom2", "angle_atom3", "num_dihedral", "dihedral_type",
+   "dihedral_atom1", "dihedral_atom2", "dihedral_atom3", "dihedral_atom4", "num_improper",
+   "improper_type", "improper_atom1", "improper_atom2", "improper_atom3", "improper_atom4"};
+  fields_create = {"q", "molecule", "residue", "num_bond", "num_angle",
+    "num_dihedral", "num_improper", "nspecial"};
+  fields_data_atom = {"id", "molecule", "residue", "type", "q", "x"};
+  fields_data_vel = {"id", "v"};
+  // clang-format on
+  setup_fields();
 
-void AtomVecAWSEM::grow(int n)
-{
-  if (n == 0) grow_nmax();
-  else nmax = n;
-  atom->nmax = nmax;
-  if (nmax < 0 || nmax > MAXSMALLINT)
-    error->one(FLERR,"Per-processor system is too big");
-
-  tag = memory->grow(atom->tag,nmax,"atom:tag");
-  type = memory->grow(atom->type,nmax,"atom:type");
-  mask = memory->grow(atom->mask,nmax,"atom:mask");
-  image = memory->grow(atom->image,nmax,"atom:image");
-  x = memory->grow(atom->x,nmax,3,"atom:x");
-  v = memory->grow(atom->v,nmax,3,"atom:v");
-  f = memory->grow(atom->f,nmax*comm->nthreads,3,"atom:f");
-
-  q = memory->grow(atom->q,nmax,"atom:q");
-  molecule = memory->grow(atom->molecule,nmax,"atom:molecule");
-  residue = memory->grow(residue,nmax,"atom:residue");
-
-  nspecial = memory->grow(atom->nspecial,nmax,3,"atom:nspecial");
-  special = memory->grow(atom->special,nmax,atom->maxspecial,"atom:special");
-
-  num_bond = memory->grow(atom->num_bond,nmax,"atom:num_bond");
-  bond_type = memory->grow(atom->bond_type,nmax,atom->bond_per_atom,
-                           "atom:bond_type");
-  bond_atom = memory->grow(atom->bond_atom,nmax,atom->bond_per_atom,
-                           "atom:bond_atom");
-
-  num_angle = memory->grow(atom->num_angle,nmax,"atom:num_angle");
-  angle_type = memory->grow(atom->angle_type,nmax,atom->angle_per_atom,
-                            "atom:angle_type");
-  angle_atom1 = memory->grow(atom->angle_atom1,nmax,atom->angle_per_atom,
-                             "atom:angle_atom1");
-  angle_atom2 = memory->grow(atom->angle_atom2,nmax,atom->angle_per_atom,
-                             "atom:angle_atom2");
-  angle_atom3 = memory->grow(atom->angle_atom3,nmax,atom->angle_per_atom,
-                             "atom:angle_atom3");
-
-  num_dihedral = memory->grow(atom->num_dihedral,nmax,"atom:num_dihedral");
-  dihedral_type = memory->grow(atom->dihedral_type,nmax,
-                               atom->dihedral_per_atom,"atom:dihedral_type");
-  dihedral_atom1 =
-    memory->grow(atom->dihedral_atom1,nmax,atom->dihedral_per_atom,
-                 "atom:dihedral_atom1");
-  dihedral_atom2 =
-    memory->grow(atom->dihedral_atom2,nmax,atom->dihedral_per_atom,
-                 "atom:dihedral_atom2");
-  dihedral_atom3 =
-    memory->grow(atom->dihedral_atom3,nmax,atom->dihedral_per_atom,
-                 "atom:dihedral_atom3");
-  dihedral_atom4 =
-    memory->grow(atom->dihedral_atom4,nmax,atom->dihedral_per_atom,
-                 "atom:dihedral_atom4");
-
-  num_improper = memory->grow(atom->num_improper,nmax,"atom:num_improper");
-  improper_type =
-    memory->grow(atom->improper_type,nmax,atom->improper_per_atom,
-                 "atom:improper_type");
-  improper_atom1 =
-    memory->grow(atom->improper_atom1,nmax,atom->improper_per_atom,
-                 "atom:improper_atom1");
-  improper_atom2 =
-    memory->grow(atom->improper_atom2,nmax,atom->improper_per_atom,
-                 "atom:improper_atom2");
-  improper_atom3 =
-    memory->grow(atom->improper_atom3,nmax,atom->improper_per_atom,
-                 "atom:improper_atom3");
-  improper_atom4 =
-    memory->grow(atom->improper_atom4,nmax,atom->improper_per_atom,
-                 "atom:improper_atom4");
-
-  if (atom->nextra_grow)
-    for (int iextra = 0; iextra < atom->nextra_grow; iextra++)
-      modify->fix[atom->extra_grow[iextra]]->grow_arrays(nmax);
-}
-
-/* ----------------------------------------------------------------------
-   reset local array ptrs
-------------------------------------------------------------------------- */
-
-void AtomVecAWSEM::grow_reset()
-{
-  tag = atom->tag; type = atom->type;
-  mask = atom->mask; image = atom->image;
-  x = atom->x; v = atom->v; f = atom->f;
-  q = atom->q; molecule = atom->molecule;
-  nspecial = atom->nspecial; special = atom->special;
-  num_bond = atom->num_bond; bond_type = atom->bond_type;
-  bond_atom = atom->bond_atom;
-  num_angle = atom->num_angle; angle_type = atom->angle_type;
-  angle_atom1 = atom->angle_atom1; angle_atom2 = atom->angle_atom2;
-  angle_atom3 = atom->angle_atom3;
-  num_dihedral = atom->num_dihedral; dihedral_type = atom->dihedral_type;
-  dihedral_atom1 = atom->dihedral_atom1; dihedral_atom2 = atom->dihedral_atom2;
-  dihedral_atom3 = atom->dihedral_atom3; dihedral_atom4 = atom->dihedral_atom4;
-  num_improper = atom->num_improper; improper_type = atom->improper_type;
-  improper_atom1 = atom->improper_atom1; improper_atom2 = atom->improper_atom2;
-  improper_atom3 = atom->improper_atom3; improper_atom4 = atom->improper_atom4;
-}
-
-/* ----------------------------------------------------------------------
-   copy atom I info to atom J
-------------------------------------------------------------------------- */
-
-void AtomVecAWSEM::copy(int i, int j, int delflag)
-{
-  int k;
-
-  tag[j] = tag[i];
-  type[j] = type[i];
-  mask[j] = mask[i];
-  image[j] = image[i];
-  x[j][0] = x[i][0];
-  x[j][1] = x[i][1];
-  x[j][2] = x[i][2];
-  v[j][0] = v[i][0];
-  v[j][1] = v[i][1];
-  v[j][2] = v[i][2];
-
-  q[j] = q[i];
-  molecule[j] = molecule[i];
-  residue[j] = residue[i];
-
-  num_bond[j] = num_bond[i];
-  for (k = 0; k < num_bond[j]; k++) {
-    bond_type[j][k] = bond_type[i][k];
-    bond_atom[j][k] = bond_atom[i][k];
-  }
-
-  num_angle[j] = num_angle[i];
-  for (k = 0; k < num_angle[j]; k++) {
-    angle_type[j][k] = angle_type[i][k];
-    angle_atom1[j][k] = angle_atom1[i][k];
-    angle_atom2[j][k] = angle_atom2[i][k];
-    angle_atom3[j][k] = angle_atom3[i][k];
-  }
-
-  num_dihedral[j] = num_dihedral[i];
-  for (k = 0; k < num_dihedral[j]; k++) {
-    dihedral_type[j][k] = dihedral_type[i][k];
-    dihedral_atom1[j][k] = dihedral_atom1[i][k];
-    dihedral_atom2[j][k] = dihedral_atom2[i][k];
-    dihedral_atom3[j][k] = dihedral_atom3[i][k];
-    dihedral_atom4[j][k] = dihedral_atom4[i][k];
-  }
-
-  num_improper[j] = num_improper[i];
-  for (k = 0; k < num_improper[j]; k++) {
-    improper_type[j][k] = improper_type[i][k];
-    improper_atom1[j][k] = improper_atom1[i][k];
-    improper_atom2[j][k] = improper_atom2[i][k];
-    improper_atom3[j][k] = improper_atom3[i][k];
-    improper_atom4[j][k] = improper_atom4[i][k];
-  }
-
-  nspecial[j][0] = nspecial[i][0];
-  nspecial[j][1] = nspecial[i][1];
-  nspecial[j][2] = nspecial[i][2];
-  for (k = 0; k < nspecial[j][2]; k++) special[j][k] = special[i][k];
-
-  if (atom->nextra_grow)
-    for (int iextra = 0; iextra < atom->nextra_grow; iextra++)
-      modify->fix[atom->extra_grow[iextra]]->copy_arrays(i,j,delflag);
+  bond_per_atom = angle_per_atom = dihedral_per_atom = improper_per_atom = 0;
+  bond_negative = angle_negative = dihedral_negative = improper_negative = nullptr;
 }
 
 /* ---------------------------------------------------------------------- */
 
-int AtomVecAWSEM::pack_comm(int n, int *list, double *buf,
-                           int pbc_flag, int *pbc)
+AtomVecAWSEM::~AtomVecAWSEM()
 {
-  int i,j,m;
-  double dx,dy,dz;
-
-  m = 0;
-  if (pbc_flag == 0) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0];
-      buf[m++] = x[j][1];
-      buf[m++] = x[j][2];
-    }
-  } else {
-    if (domain->triclinic == 0) {
-      dx = pbc[0]*domain->xprd;
-      dy = pbc[1]*domain->yprd;
-      dz = pbc[2]*domain->zprd;
-    } else {
-      dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
-      dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
-      dz = pbc[2]*domain->zprd;
-    }
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0] + dx;
-      buf[m++] = x[j][1] + dy;
-      buf[m++] = x[j][2] + dz;
-    }
-  }
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_comm_vel(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
-{
-  int i,j,m;
-  double dx,dy,dz,dvx,dvy,dvz;
-
-  m = 0;
-  if (pbc_flag == 0) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0];
-      buf[m++] = x[j][1];
-      buf[m++] = x[j][2];
-      buf[m++] = v[j][0];
-      buf[m++] = v[j][1];
-      buf[m++] = v[j][2];
-    }
-  } else {
-    if (domain->triclinic == 0) {
-      dx = pbc[0]*domain->xprd;
-      dy = pbc[1]*domain->yprd;
-      dz = pbc[2]*domain->zprd;
-    } else {
-      dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
-      dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
-      dz = pbc[2]*domain->zprd;
-    }
-    if (!deform_vremap) {
-      for (i = 0; i < n; i++) {
-        j = list[i];
-        buf[m++] = x[j][0] + dx;
-        buf[m++] = x[j][1] + dy;
-        buf[m++] = x[j][2] + dz;
-        buf[m++] = v[j][0];
-        buf[m++] = v[j][1];
-        buf[m++] = v[j][2];
-      }
-    } else {
-      dvx = pbc[0]*h_rate[0] + pbc[5]*h_rate[5] + pbc[4]*h_rate[4];
-      dvy = pbc[1]*h_rate[1] + pbc[3]*h_rate[3];
-      dvz = pbc[2]*h_rate[2];
-      for (i = 0; i < n; i++) {
-        j = list[i];
-        buf[m++] = x[j][0] + dx;
-        buf[m++] = x[j][1] + dy;
-        buf[m++] = x[j][2] + dz;
-        if (mask[i] & deform_groupbit) {
-          buf[m++] = v[j][0] + dvx;
-          buf[m++] = v[j][1] + dvy;
-          buf[m++] = v[j][2] + dvz;
-        } else {
-          buf[m++] = v[j][0];
-          buf[m++] = v[j][1];
-          buf[m++] = v[j][2];
-        }
-      }
-    }
-  }
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-void AtomVecAWSEM::unpack_comm(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    x[i][0] = buf[m++];
-    x[i][1] = buf[m++];
-    x[i][2] = buf[m++];
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
-void AtomVecAWSEM::unpack_comm_vel(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    x[i][0] = buf[m++];
-    x[i][1] = buf[m++];
-    x[i][2] = buf[m++];
-    v[i][0] = buf[m++];
-    v[i][1] = buf[m++];
-    v[i][2] = buf[m++];
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_reverse(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    buf[m++] = f[i][0];
-    buf[m++] = f[i][1];
-    buf[m++] = f[i][2];
-  }
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-void AtomVecAWSEM::unpack_reverse(int n, int *list, double *buf)
-{
-  int i,j,m;
-
-  m = 0;
-  for (i = 0; i < n; i++) {
-    j = list[i];
-    f[j][0] += buf[m++];
-    f[j][1] += buf[m++];
-    f[j][2] += buf[m++];
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_border(int n, int *list, double *buf,
-                             int pbc_flag, int *pbc)
-{
-  int i,j,m;
-  double dx,dy,dz;
-
-  m = 0;
-  if (pbc_flag == 0) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0];
-      buf[m++] = x[j][1];
-      buf[m++] = x[j][2];
-      buf[m++] = ubuf(tag[j]).d;
-      buf[m++] = ubuf(type[j]).d;
-      buf[m++] = ubuf(mask[j]).d;
-      buf[m++] = q[j];
-      buf[m++] = ubuf(molecule[j]).d;
-      buf[m++] = ubuf(residue[j]).d;
-    }
-  } else {
-    if (domain->triclinic == 0) {
-      dx = pbc[0]*domain->xprd;
-      dy = pbc[1]*domain->yprd;
-      dz = pbc[2]*domain->zprd;
-    } else {
-      dx = pbc[0];
-      dy = pbc[1];
-      dz = pbc[2];
-    }
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0] + dx;
-      buf[m++] = x[j][1] + dy;
-      buf[m++] = x[j][2] + dz;
-      buf[m++] = ubuf(tag[j]).d;
-      buf[m++] = ubuf(type[j]).d;
-      buf[m++] = ubuf(mask[j]).d;
-      buf[m++] = q[j];
-      buf[m++] = ubuf(molecule[j]).d;
-      buf[m++] = ubuf(residue[j]).d;
-    }
-  }
-
-  if (atom->nextra_border)
-    for (int iextra = 0; iextra < atom->nextra_border; iextra++)
-      m += modify->fix[atom->extra_border[iextra]]->pack_border(n,list,&buf[m]);
-
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_border_vel(int n, int *list, double *buf,
-                                 int pbc_flag, int *pbc)
-{
-  int i,j,m;
-  double dx,dy,dz,dvx,dvy,dvz;
-
-  m = 0;
-  if (pbc_flag == 0) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0];
-      buf[m++] = x[j][1];
-      buf[m++] = x[j][2];
-      buf[m++] = ubuf(tag[j]).d;
-      buf[m++] = ubuf(type[j]).d;
-      buf[m++] = ubuf(mask[j]).d;
-      buf[m++] = q[j];
-      buf[m++] = ubuf(molecule[j]).d;
-      buf[m++] = ubuf(residue[j]).d;
-      buf[m++] = v[j][0];
-      buf[m++] = v[j][1];
-      buf[m++] = v[j][2];
-    }
-  } else {
-    if (domain->triclinic == 0) {
-      dx = pbc[0]*domain->xprd;
-      dy = pbc[1]*domain->yprd;
-      dz = pbc[2]*domain->zprd;
-    } else {
-      dx = pbc[0];
-      dy = pbc[1];
-      dz = pbc[2];
-    }
-    if (!deform_vremap) {
-      for (i = 0; i < n; i++) {
-        j = list[i];
-        buf[m++] = x[j][0] + dx;
-        buf[m++] = x[j][1] + dy;
-        buf[m++] = x[j][2] + dz;
-        buf[m++] = ubuf(tag[j]).d;
-        buf[m++] = ubuf(type[j]).d;
-        buf[m++] = ubuf(mask[j]).d;
-        buf[m++] = q[j];
-        buf[m++] = ubuf(molecule[j]).d;
-        buf[m++] = ubuf(residue[j]).d;
-        buf[m++] = v[j][0];
-        buf[m++] = v[j][1];
-        buf[m++] = v[j][2];
-      }
-    } else {
-      dvx = pbc[0]*h_rate[0] + pbc[5]*h_rate[5] + pbc[4]*h_rate[4];
-      dvy = pbc[1]*h_rate[1] + pbc[3]*h_rate[3];
-      dvz = pbc[2]*h_rate[2];
-      for (i = 0; i < n; i++) {
-        j = list[i];
-        buf[m++] = x[j][0] + dx;
-        buf[m++] = x[j][1] + dy;
-        buf[m++] = x[j][2] + dz;
-        buf[m++] = ubuf(tag[j]).d;
-        buf[m++] = ubuf(type[j]).d;
-        buf[m++] = ubuf(mask[j]).d;
-        buf[m++] = q[j];
-        buf[m++] = ubuf(molecule[j]).d;
-        buf[m++] = ubuf(residue[j]).d;
-        if (mask[i] & deform_groupbit) {
-          buf[m++] = v[j][0] + dvx;
-          buf[m++] = v[j][1] + dvy;
-          buf[m++] = v[j][2] + dvz;
-        } else {
-          buf[m++] = v[j][0];
-          buf[m++] = v[j][1];
-          buf[m++] = v[j][2];
-        }
-      }
-    }
-  }
-
-  if (atom->nextra_border)
-    for (int iextra = 0; iextra < atom->nextra_border; iextra++)
-      m += modify->fix[atom->extra_border[iextra]]->pack_border(n,list,&buf[m]);
-
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_border_hybrid(int n, int *list, double *buf)
-{
-  int i,j,m;
-
-  m = 0;
-  for (i = 0; i < n; i++) {
-    j = list[i];
-    buf[m++] = q[j];
-    buf[m++] = ubuf(molecule[j]).d;
-    buf[m++] = ubuf(residue[j]).d;
-  }
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-void AtomVecAWSEM::unpack_border(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    if (i == nmax) grow(0);
-    x[i][0] = buf[m++];
-    x[i][1] = buf[m++];
-    x[i][2] = buf[m++];
-    tag[i] = (tagint) ubuf(buf[m++]).i;
-    type[i] = (int) ubuf(buf[m++]).i;
-    mask[i] = (int) ubuf(buf[m++]).i;
-    q[i] = buf[m++];
-    molecule[i] = (tagint) ubuf(buf[m++]).i;
-    residue[i] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  if (atom->nextra_border)
-    for (int iextra = 0; iextra < atom->nextra_border; iextra++)
-      m += modify->fix[atom->extra_border[iextra]]->
-        unpack_border(n,first,&buf[m]);
-}
-
-/* ---------------------------------------------------------------------- */
-
-void AtomVecAWSEM::unpack_border_vel(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    if (i == nmax) grow(0);
-    x[i][0] = buf[m++];
-    x[i][1] = buf[m++];
-    x[i][2] = buf[m++];
-    tag[i] = (tagint) ubuf(buf[m++]).i;
-    type[i] = (int) ubuf(buf[m++]).i;
-    mask[i] = (int) ubuf(buf[m++]).i;
-    q[i] = buf[m++];
-    molecule[i] = (tagint) ubuf(buf[m++]).i;
-    residue[i] = (tagint) ubuf(buf[m++]).i;
-    v[i][0] = buf[m++];
-    v[i][1] = buf[m++];
-    v[i][2] = buf[m++];
-  }
-
-  if (atom->nextra_border)
-    for (int iextra = 0; iextra < atom->nextra_border; iextra++)
-      m += modify->fix[atom->extra_border[iextra]]->
-        unpack_border(n,first,&buf[m]);
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::unpack_border_hybrid(int n, int first, double *buf)
-{
-  int i,m,last;
-
-  m = 0;
-  last = first + n;
-  for (i = first; i < last; i++) {
-    q[i] = buf[m++];
-    molecule[i] = (tagint) ubuf(buf[m++]).i;
-    residue[i] = (tagint) ubuf(buf[m++]).i;
-  }
-  return m;
+  delete[] bond_negative;
+  delete[] angle_negative;
+  delete[] dihedral_negative;
+  delete[] improper_negative;
 }
 
 /* ----------------------------------------------------------------------
-   pack data for atom I for sending to another proc
-   xyz must be 1st 3 values, so comm::exchange() can test on them
+   set local copies of all grow ptrs used by this class, except defaults
+   needed in replicate when 2 atom classes exist and it calls pack_restart()
 ------------------------------------------------------------------------- */
 
-int AtomVecAWSEM::pack_exchange(int i, double *buf)
+void AtomVecAWSEM::grow_pointers()
 {
-  int k;
-
-  int m = 1;
-  buf[m++] = x[i][0];
-  buf[m++] = x[i][1];
-  buf[m++] = x[i][2];
-  buf[m++] = v[i][0];
-  buf[m++] = v[i][1];
-  buf[m++] = v[i][2];
-  buf[m++] = ubuf(tag[i]).d;
-  buf[m++] = ubuf(type[i]).d;
-  buf[m++] = ubuf(mask[i]).d;
-  buf[m++] = ubuf(image[i]).d;
-
-  buf[m++] = q[i];
-  buf[m++] = ubuf(molecule[i]).d;
-  buf[m++] = ubuf(residue[i]).d;
-
-  buf[m++] = ubuf(num_bond[i]).d;
-  for (k = 0; k < num_bond[i]; k++) {
-    buf[m++] = ubuf(bond_type[i][k]).d;
-    buf[m++] = ubuf(bond_atom[i][k]).d;
-  }
-
-  buf[m++] = ubuf(num_angle[i]).d;
-  for (k = 0; k < num_angle[i]; k++) {
-    buf[m++] = ubuf(angle_type[i][k]).d;
-    buf[m++] = ubuf(angle_atom1[i][k]).d;
-    buf[m++] = ubuf(angle_atom2[i][k]).d;
-    buf[m++] = ubuf(angle_atom3[i][k]).d;
-  }
-
-  buf[m++] = ubuf(num_dihedral[i]).d;
-  for (k = 0; k < num_dihedral[i]; k++) {
-    buf[m++] = ubuf(dihedral_type[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom1[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom2[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom3[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom4[i][k]).d;
-  }
-
-  buf[m++] = ubuf(num_improper[i]).d;
-  for (k = 0; k < num_improper[i]; k++) {
-    buf[m++] = ubuf(improper_type[i][k]).d;
-    buf[m++] = ubuf(improper_atom1[i][k]).d;
-    buf[m++] = ubuf(improper_atom2[i][k]).d;
-    buf[m++] = ubuf(improper_atom3[i][k]).d;
-    buf[m++] = ubuf(improper_atom4[i][k]).d;
-  }
-
-  buf[m++] = ubuf(nspecial[i][0]).d;
-  buf[m++] = ubuf(nspecial[i][1]).d;
-  buf[m++] = ubuf(nspecial[i][2]).d;
-  for (k = 0; k < nspecial[i][2]; k++) buf[m++] = ubuf(special[i][k]).d;
-
-  if (atom->nextra_grow)
-    for (int iextra = 0; iextra < atom->nextra_grow; iextra++)
-      m += modify->fix[atom->extra_grow[iextra]]->pack_exchange(i,&buf[m]);
-
-  buf[0] = m;
-  return m;
-}
-
-/* ---------------------------------------------------------------------- */
-
-int AtomVecAWSEM::unpack_exchange(double *buf)
-{
-  int k;
-
-  int nlocal = atom->nlocal;
-  if (nlocal == nmax) grow(0);
-
-  int m = 1;
-  x[nlocal][0] = buf[m++];
-  x[nlocal][1] = buf[m++];
-  x[nlocal][2] = buf[m++];
-  v[nlocal][0] = buf[m++];
-  v[nlocal][1] = buf[m++];
-  v[nlocal][2] = buf[m++];
-  tag[nlocal] = (tagint) ubuf(buf[m++]).i;
-  type[nlocal] = (int) ubuf(buf[m++]).i;
-  mask[nlocal] = (int) ubuf(buf[m++]).i;
-  image[nlocal] = (imageint) ubuf(buf[m++]).i;
-
-  q[nlocal] = buf[m++];
-  molecule[nlocal] = (tagint) ubuf(buf[m++]).i;
-  residue[nlocal] = (tagint) ubuf(buf[m++]).i;
-
-  num_bond[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_bond[nlocal]; k++) {
-    bond_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    bond_atom[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_angle[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_angle[nlocal]; k++) {
-    angle_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    angle_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    angle_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    angle_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_dihedral[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_dihedral[nlocal]; k++) {
-    dihedral_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    dihedral_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom4[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_improper[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_improper[nlocal]; k++) {
-    improper_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    improper_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom4[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  nspecial[nlocal][0] = (int) ubuf(buf[m++]).i;
-  nspecial[nlocal][1] = (int) ubuf(buf[m++]).i;
-  nspecial[nlocal][2] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < nspecial[nlocal][2]; k++)
-    special[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-
-  if (atom->nextra_grow)
-    for (int iextra = 0; iextra < atom->nextra_grow; iextra++)
-      m += modify->fix[atom->extra_grow[iextra]]->
-        unpack_exchange(nlocal,&buf[m]);
-
-  atom->nlocal++;
-  return m;
+  num_bond = atom->num_bond;
+  bond_type = atom->bond_type;
+  num_angle = atom->num_angle;
+  angle_type = atom->angle_type;
+  num_dihedral = atom->num_dihedral;
+  dihedral_type = atom->dihedral_type;
+  num_improper = atom->num_improper;
+  improper_type = atom->improper_type;
+  nspecial = atom->nspecial;
 }
 
 /* ----------------------------------------------------------------------
-   size of restart data for all atoms owned by this proc
-   include extra data stored by fixes
+   modify values for AtomVec::pack_restart() to pack
 ------------------------------------------------------------------------- */
 
-int AtomVecAWSEM::size_restart()
+void AtomVecAWSEM::pack_restart_pre(int ilocal)
 {
-  int i;
+  // ensure negative vectors are needed length
 
-  int nlocal = atom->nlocal;
-  int n = 0;
-  for (i = 0; i < nlocal; i++)
-    n += 18 + 2*num_bond[i] + 4*num_angle[i] +
-      5*num_dihedral[i] + 5*num_improper[i];
-
-  if (atom->nextra_restart)
-    for (int iextra = 0; iextra < atom->nextra_restart; iextra++)
-      for (i = 0; i < nlocal; i++)
-        n += modify->fix[atom->extra_restart[iextra]]->size_restart(i);
-
-  return n;
-}
-
-/* ----------------------------------------------------------------------
-   pack atom I's data for restart file including extra quantities
-   xyz must be 1st 3 values, so that read_restart can test on them
-   molecular types may be negative, but write as positive
-------------------------------------------------------------------------- */
-
-int AtomVecAWSEM::pack_restart(int i, double *buf)
-{
-  int k;
-
-  int m = 1;
-  buf[m++] = x[i][0];
-  buf[m++] = x[i][1];
-  buf[m++] = x[i][2];
-  buf[m++] = ubuf(tag[i]).d;
-  buf[m++] = ubuf(type[i]).d;
-  buf[m++] = ubuf(mask[i]).d;
-  buf[m++] = ubuf(image[i]).d;
-  buf[m++] = v[i][0];
-  buf[m++] = v[i][1];
-  buf[m++] = v[i][2];
-
-  buf[m++] = q[i];
-  buf[m++] = ubuf(molecule[i]).d;
-  buf[m++] = ubuf(residue[i]).d;
-
-  buf[m++] = ubuf(num_bond[i]).d;
-  for (k = 0; k < num_bond[i]; k++) {
-    buf[m++] = ubuf(MAX(bond_type[i][k],-bond_type[i][k])).d;
-    buf[m++] = ubuf(bond_atom[i][k]).d;
+  if (bond_per_atom < atom->bond_per_atom) {
+    delete[] bond_negative;
+    bond_per_atom = atom->bond_per_atom;
+    bond_negative = new int[bond_per_atom];
+  }
+  if (angle_per_atom < atom->angle_per_atom) {
+    delete[] angle_negative;
+    angle_per_atom = atom->angle_per_atom;
+    angle_negative = new int[angle_per_atom];
+  }
+  if (dihedral_per_atom < atom->dihedral_per_atom) {
+    delete[] dihedral_negative;
+    dihedral_per_atom = atom->dihedral_per_atom;
+    dihedral_negative = new int[dihedral_per_atom];
+  }
+  if (improper_per_atom < atom->improper_per_atom) {
+    delete[] improper_negative;
+    improper_per_atom = atom->improper_per_atom;
+    improper_negative = new int[improper_per_atom];
   }
 
-  buf[m++] = ubuf(num_angle[i]).d;
-  for (k = 0; k < num_angle[i]; k++) {
-    buf[m++] = ubuf(MAX(angle_type[i][k],-angle_type[i][k])).d;
-    buf[m++] = ubuf(angle_atom1[i][k]).d;
-    buf[m++] = ubuf(angle_atom2[i][k]).d;
-    buf[m++] = ubuf(angle_atom3[i][k]).d;
+  // flip any negative types to positive and flag which ones
+
+  any_bond_negative = 0;
+  for (int m = 0; m < num_bond[ilocal]; m++) {
+    if (bond_type[ilocal][m] < 0) {
+      bond_negative[m] = 1;
+      bond_type[ilocal][m] = -bond_type[ilocal][m];
+      any_bond_negative = 1;
+    } else
+      bond_negative[m] = 0;
   }
 
-  buf[m++] = ubuf(num_dihedral[i]).d;
-  for (k = 0; k < num_dihedral[i]; k++) {
-    buf[m++] = ubuf(MAX(dihedral_type[i][k],-dihedral_type[i][k])).d;
-    buf[m++] = ubuf(dihedral_atom1[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom2[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom3[i][k]).d;
-    buf[m++] = ubuf(dihedral_atom4[i][k]).d;
+  any_angle_negative = 0;
+  for (int m = 0; m < num_angle[ilocal]; m++) {
+    if (angle_type[ilocal][m] < 0) {
+      angle_negative[m] = 1;
+      angle_type[ilocal][m] = -angle_type[ilocal][m];
+      any_angle_negative = 1;
+    } else
+      angle_negative[m] = 0;
   }
 
-  buf[m++] = ubuf(num_improper[i]).d;
-  for (k = 0; k < num_improper[i]; k++) {
-    buf[m++] = ubuf(MAX(improper_type[i][k],-improper_type[i][k])).d;
-    buf[m++] = ubuf(improper_atom1[i][k]).d;
-    buf[m++] = ubuf(improper_atom2[i][k]).d;
-    buf[m++] = ubuf(improper_atom3[i][k]).d;
-    buf[m++] = ubuf(improper_atom4[i][k]).d;
+  any_dihedral_negative = 0;
+  for (int m = 0; m < num_dihedral[ilocal]; m++) {
+    if (dihedral_type[ilocal][m] < 0) {
+      dihedral_negative[m] = 1;
+      dihedral_type[ilocal][m] = -dihedral_type[ilocal][m];
+      any_dihedral_negative = 1;
+    } else
+      dihedral_negative[m] = 0;
   }
 
-  if (atom->nextra_restart)
-    for (int iextra = 0; iextra < atom->nextra_restart; iextra++)
-      m += modify->fix[atom->extra_restart[iextra]]->pack_restart(i,&buf[m]);
-
-  buf[0] = m;
-  return m;
-}
-
-/* ----------------------------------------------------------------------
-   unpack data for one atom from restart file including extra quantities
-------------------------------------------------------------------------- */
-
-int AtomVecAWSEM::unpack_restart(double *buf)
-{
-  int k;
-
-  int nlocal = atom->nlocal;
-  if (nlocal == nmax) {
-    grow(0);
-    if (atom->nextra_store)
-      memory->grow(atom->extra,nmax,atom->nextra_store,"atom:extra");
-  }
-
-  int m = 1;
-  x[nlocal][0] = buf[m++];
-  x[nlocal][1] = buf[m++];
-  x[nlocal][2] = buf[m++];
-  tag[nlocal] = (tagint) ubuf(buf[m++]).i;
-  type[nlocal] = (int) ubuf(buf[m++]).i;
-  mask[nlocal] = (int) ubuf(buf[m++]).i;
-  image[nlocal] = (imageint) ubuf(buf[m++]).i;
-  v[nlocal][0] = buf[m++];
-  v[nlocal][1] = buf[m++];
-  v[nlocal][2] = buf[m++];
-
-  q[nlocal] = buf[m++];
-  molecule[nlocal] = (tagint) ubuf(buf[m++]).i;
-  residue[nlocal] = (tagint) ubuf(buf[m++]).i;
-
-  num_bond[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_bond[nlocal]; k++) {
-    bond_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    bond_atom[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_angle[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_angle[nlocal]; k++) {
-    angle_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    angle_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    angle_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    angle_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_dihedral[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_dihedral[nlocal]; k++) {
-    dihedral_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    dihedral_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    dihedral_atom4[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  num_improper[nlocal] = (int) ubuf(buf[m++]).i;
-  for (k = 0; k < num_improper[nlocal]; k++) {
-    improper_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    improper_atom1[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom2[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom3[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-    improper_atom4[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-
-  nspecial[nlocal][0] = nspecial[nlocal][1] = nspecial[nlocal][2] = 0;
-
-  double **extra = atom->extra;
-  if (atom->nextra_store) {
-    int size = static_cast<int> (buf[0]) - m;
-    for (int i = 0; i < size; i++) extra[nlocal][i] = buf[m++];
-  }
-
-  atom->nlocal++;
-  return m;
-}
-
-/* ----------------------------------------------------------------------
-   create one atom of itype at coord
-   set other values to defaults
-------------------------------------------------------------------------- */
-
-void AtomVecAWSEM::create_atom(int itype, double *coord)
-{
-  int nlocal = atom->nlocal;
-  if (nlocal == nmax) grow(0);
-
-  tag[nlocal] = 0;
-  type[nlocal] = itype;
-  x[nlocal][0] = coord[0];
-  x[nlocal][1] = coord[1];
-  x[nlocal][2] = coord[2];
-  mask[nlocal] = 1;
-  image[nlocal] = ((imageint) IMGMAX << IMG2BITS) |
-    ((imageint) IMGMAX << IMGBITS) | IMGMAX;
-  v[nlocal][0] = 0.0;
-  v[nlocal][1] = 0.0;
-  v[nlocal][2] = 0.0;
-
-  q[nlocal] = 0.0;
-  molecule[nlocal] = 0;
-  residue[nlocal] = 0;
-  num_bond[nlocal] = 0;
-  num_angle[nlocal] = 0;
-  num_dihedral[nlocal] = 0;
-  num_improper[nlocal] = 0;
-  nspecial[nlocal][0] = nspecial[nlocal][1] = nspecial[nlocal][2] = 0;
-
-  atom->nlocal++;
-}
-
-/* ----------------------------------------------------------------------
-   unpack one line from Atoms section of data file
-   initialize other atom quantities
-------------------------------------------------------------------------- */
-
-void AtomVecAWSEM::data_atom(double *coord, imageint imagetmp, char **values)
-{
-  int nlocal = atom->nlocal;
-  if (nlocal == nmax) grow(0);
-
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
-  residue[nlocal] = ATOTAGINT(values[2]);
-  type[nlocal] = atoi(values[3]);
-  if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
-    error->one(FLERR,"Invalid atom type in Atoms section of data file");
-
-  q[nlocal] = atof(values[4]);
-
-  x[nlocal][0] = coord[0];
-  x[nlocal][1] = coord[1];
-  x[nlocal][2] = coord[2];
-
-  image[nlocal] = imagetmp;
-
-  mask[nlocal] = 1;
-  v[nlocal][0] = 0.0;
-  v[nlocal][1] = 0.0;
-  v[nlocal][2] = 0.0;
-  num_bond[nlocal] = 0;
-  num_angle[nlocal] = 0;
-  num_dihedral[nlocal] = 0;
-  num_improper[nlocal] = 0;
-
-  atom->nlocal++;
-}
-
-/* ----------------------------------------------------------------------
-   unpack hybrid quantities from one line in Atoms section of data file
-   initialize other atom quantities for this sub-style
-------------------------------------------------------------------------- */
-
-int AtomVecAWSEM::data_atom_hybrid(int nlocal, char **values)
-{
-  molecule[nlocal] = ATOTAGINT(values[0]);
-  residue[nlocal] = ATOTAGINT(values[1]);
-  q[nlocal] = atof(values[2]);
-
-  num_bond[nlocal] = 0;
-  num_angle[nlocal] = 0;
-  num_dihedral[nlocal] = 0;
-  num_improper[nlocal] = 0;
-
-  return 3;
-}
-
-/* ----------------------------------------------------------------------
-   pack atom info for data file including 3 image flags
-------------------------------------------------------------------------- */
-
-void AtomVecAWSEM::pack_data(double **buf)
-{
-  int nlocal = atom->nlocal;
-  for (int i = 0; i < nlocal; i++) {
-    buf[i][0] = ubuf(tag[i]).d;
-    buf[i][1] = ubuf(molecule[i]).d;
-    buf[i][2] = ubuf(residue[i]).d;
-    buf[i][3] = ubuf(type[i]).d;
-    buf[i][4] = q[i];
-    buf[i][5] = x[i][0];
-    buf[i][6] = x[i][1];
-    buf[i][7] = x[i][2];
-    buf[i][8] = ubuf((image[i] & IMGMASK) - IMGMAX).d;
-    buf[i][9] = ubuf((image[i] >> IMGBITS & IMGMASK) - IMGMAX).d;
-    buf[i][10] = ubuf((image[i] >> IMG2BITS) - IMGMAX).d;
+  any_improper_negative = 0;
+  for (int m = 0; m < num_improper[ilocal]; m++) {
+    if (improper_type[ilocal][m] < 0) {
+      improper_negative[m] = 1;
+      improper_type[ilocal][m] = -improper_type[ilocal][m];
+      any_improper_negative = 1;
+    } else
+      improper_negative[m] = 0;
   }
 }
 
 /* ----------------------------------------------------------------------
-   pack hybrid atom info for data file
+   unmodify values packed by AtomVec::pack_restart()
 ------------------------------------------------------------------------- */
 
-int AtomVecAWSEM::pack_data_hybrid(int i, double *buf)
+void AtomVecAWSEM::pack_restart_post(int ilocal)
 {
-  buf[0] = ubuf(molecule[i]).d;
-  buf[1] = ubuf(residue[i]).d;
-  buf[2] = q[i];
-  return 3;
+  // restore the flagged types to their negative values
+
+  if (any_bond_negative) {
+    for (int m = 0; m < num_bond[ilocal]; m++)
+      if (bond_negative[m]) bond_type[ilocal][m] = -bond_type[ilocal][m];
+  }
+
+  if (any_angle_negative) {
+    for (int m = 0; m < num_angle[ilocal]; m++)
+      if (angle_negative[m]) angle_type[ilocal][m] = -angle_type[ilocal][m];
+  }
+
+  if (any_dihedral_negative) {
+    for (int m = 0; m < num_dihedral[ilocal]; m++)
+      if (dihedral_negative[m]) dihedral_type[ilocal][m] = -dihedral_type[ilocal][m];
+  }
+
+  if (any_improper_negative) {
+    for (int m = 0; m < num_improper[ilocal]; m++)
+      if (improper_negative[m]) improper_type[ilocal][m] = -improper_type[ilocal][m];
+  }
 }
 
 /* ----------------------------------------------------------------------
-   write atom info to data file including 3 image flags
+   initialize other atom quantities after AtomVec::unpack_restart()
 ------------------------------------------------------------------------- */
 
-void AtomVecAWSEM::write_data(FILE *fp, int n, double **buf)
+void AtomVecAWSEM::unpack_restart_init(int ilocal)
 {
-  for (int i = 0; i < n; i++)
-    fprintf(fp,TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
-            " %d %-1.16e %-1.16e %-1.16e %-1.16e %d %d %d\n",
-            (tagint) ubuf(buf[i][0]).i,(tagint) ubuf(buf[i][1]).i,
-            (tagint) ubuf(buf[i][2]).i,(int) ubuf(buf[i][3]).i,
-            buf[i][4],buf[i][5],buf[i][6],buf[i][7],
-            (int) ubuf(buf[i][8]).i,(int) ubuf(buf[i][9]).i,
-            (int) ubuf(buf[i][10]).i);
+  nspecial[ilocal][0] = 0;
+  nspecial[ilocal][1] = 0;
+  nspecial[ilocal][2] = 0;
 }
 
 /* ----------------------------------------------------------------------
-   write hybrid atom info to data file
+   modify what AtomVec::data_atom() just unpacked
+   or initialize other atom quantities
 ------------------------------------------------------------------------- */
 
-int AtomVecAWSEM::write_data_hybrid(FILE *fp, double *buf)
+void AtomVecAWSEM::data_atom_post(int ilocal)
 {
-  fprintf(fp," " TAGINT_FORMAT " " TAGINT_FORMAT " %-1.16e",(tagint) ubuf(buf[0]).i,(tagint) ubuf(buf[1]).i,buf[2]);
-  return 3;
-}
-
-/* ----------------------------------------------------------------------
-   return # of bytes of allocated memory
-------------------------------------------------------------------------- */
-
-double AtomVecAWSEM::memory_usage()
-{
-  bigint bytes = 0;
-
-  if (atom->memcheck("tag")) bytes += memory->usage(tag,nmax);
-  if (atom->memcheck("type")) bytes += memory->usage(type,nmax);
-  if (atom->memcheck("mask")) bytes += memory->usage(mask,nmax);
-  if (atom->memcheck("image")) bytes += memory->usage(image,nmax);
-  if (atom->memcheck("x")) bytes += memory->usage(x,nmax,3);
-  if (atom->memcheck("v")) bytes += memory->usage(v,nmax,3);
-  if (atom->memcheck("f")) bytes += memory->usage(f,nmax*comm->nthreads,3);
-
-  if (atom->memcheck("q")) bytes += memory->usage(q,nmax);
-  if (atom->memcheck("molecule")) bytes += memory->usage(molecule,nmax);
-  if (atom->memcheck("residue")) bytes += memory->usage(residue,nmax);
-  if (atom->memcheck("nspecial")) bytes += memory->usage(nspecial,nmax,3);
-  if (atom->memcheck("special"))
-    bytes += memory->usage(special,nmax,atom->maxspecial);
-
-  if (atom->memcheck("num_bond")) bytes += memory->usage(num_bond,nmax);
-  if (atom->memcheck("bond_type"))
-    bytes += memory->usage(bond_type,nmax,atom->bond_per_atom);
-  if (atom->memcheck("bond_atom"))
-    bytes += memory->usage(bond_atom,nmax,atom->bond_per_atom);
-
-  if (atom->memcheck("num_angle")) bytes += memory->usage(num_angle,nmax);
-  if (atom->memcheck("angle_type"))
-    bytes += memory->usage(angle_type,nmax,atom->angle_per_atom);
-  if (atom->memcheck("angle_atom1"))
-    bytes += memory->usage(angle_atom1,nmax,atom->angle_per_atom);
-  if (atom->memcheck("angle_atom2"))
-    bytes += memory->usage(angle_atom2,nmax,atom->angle_per_atom);
-  if (atom->memcheck("angle_atom3"))
-    bytes += memory->usage(angle_atom3,nmax,atom->angle_per_atom);
-
-  if (atom->memcheck("num_dihedral")) bytes += memory->usage(num_dihedral,nmax);
-  if (atom->memcheck("dihedral_type"))
-    bytes += memory->usage(dihedral_type,nmax,atom->dihedral_per_atom);
-  if (atom->memcheck("dihedral_atom1"))
-    bytes += memory->usage(dihedral_atom1,nmax,atom->dihedral_per_atom);
-  if (atom->memcheck("dihedral_atom2"))
-    bytes += memory->usage(dihedral_atom2,nmax,atom->dihedral_per_atom);
-  if (atom->memcheck("dihedral_atom3"))
-    bytes += memory->usage(dihedral_atom3,nmax,atom->dihedral_per_atom);
-  if (atom->memcheck("dihedral_atom4"))
-    bytes += memory->usage(dihedral_atom4,nmax,atom->dihedral_per_atom);
-
-  if (atom->memcheck("num_improper")) bytes += memory->usage(num_improper,nmax);
-  if (atom->memcheck("improper_type"))
-    bytes += memory->usage(improper_type,nmax,atom->improper_per_atom);
-  if (atom->memcheck("improper_atom1"))
-    bytes += memory->usage(improper_atom1,nmax,atom->improper_per_atom);
-  if (atom->memcheck("improper_atom2"))
-    bytes += memory->usage(improper_atom2,nmax,atom->improper_per_atom);
-  if (atom->memcheck("improper_atom3"))
-    bytes += memory->usage(improper_atom3,nmax,atom->improper_per_atom);
-  if (atom->memcheck("improper_atom4"))
-    bytes += memory->usage(improper_atom4,nmax,atom->improper_per_atom);
-
-  return bytes;
+  num_bond[ilocal] = 0;
+  num_angle[ilocal] = 0;
+  num_dihedral[ilocal] = 0;
+  num_improper[ilocal] = 0;
+  nspecial[ilocal][0] = 0;
+  nspecial[ilocal][1] = 0;
+  nspecial[ilocal][2] = 0;
 }

--- a/src/atom_vec_awsemmd.h
+++ b/src/atom_vec_awsemmd.h
@@ -1,7 +1,7 @@
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   http://lammps.sandia.gov, Sandia National Laboratories
-   Steve Plimpton, sjplimp@sandia.gov
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
@@ -12,9 +12,9 @@
 ------------------------------------------------------------------------- */
 
 #ifdef ATOM_CLASS
-
-AtomStyle(awsemmd,AtomVecAWSEM)
-
+// clang-format off
+AtomStyle(awsemmd,AtomVecAWSEM);
+// clang-format on
 #else
 
 #ifndef LMP_ATOM_VEC_AWSEM_H
@@ -27,75 +27,25 @@ namespace LAMMPS_NS {
 class AtomVecAWSEM : public AtomVec {
  public:
   AtomVecAWSEM(class LAMMPS *);
-  virtual ~AtomVecAWSEM() {}
-  virtual void grow(int);
-  virtual void grow_reset();
-  virtual void copy(int, int, int);
-  virtual int pack_comm(int, int *, double *, int, int *);
-  virtual int pack_comm_vel(int, int *, double *, int, int *);
-  virtual void unpack_comm(int, int, double *);
-  virtual void unpack_comm_vel(int, int, double *);
-  virtual int pack_reverse(int, int, double *);
-  virtual void unpack_reverse(int, int *, double *);
-  virtual int pack_border(int, int *, double *, int, int *);
-  virtual int pack_border_vel(int, int *, double *, int, int *);
-  virtual int pack_border_hybrid(int, int *, double *);
-  virtual void unpack_border(int, int, double *);
-  virtual void unpack_border_vel(int, int, double *);
-  virtual int unpack_border_hybrid(int, int, double *);
-  virtual int pack_exchange(int, double *);
-  virtual int unpack_exchange(double *);
-  virtual int size_restart();
-  virtual int pack_restart(int, double *);
-  virtual int unpack_restart(double *);
-  virtual void create_atom(int, double *);
-  virtual void data_atom(double *, imageint, char **);
-  virtual int data_atom_hybrid(int, char **);
-  virtual void pack_data(double **);
-  virtual int pack_data_hybrid(int, double *);
-  virtual void write_data(FILE *, int, double **);
-  virtual int write_data_hybrid(FILE *, double *);
-  virtual double memory_usage();
+  ~AtomVecAWSEM() override;
 
-  tagint *residue; 
+  void grow_pointers() override;
+  void pack_restart_pre(int) override;
+  void pack_restart_post(int) override;
+  void unpack_restart_init(int) override;
+  void data_atom_post(int) override;
 
- protected:
-  tagint *tag;
-  int *type,*mask;
-  imageint *image;
-  double **x,**v,**f;
-  double *q;
-  tagint *molecule;
+ private:
+  int *num_bond, *num_angle, *num_dihedral, *num_improper;
+  int **bond_type, **angle_type, **dihedral_type, **improper_type;
   int **nspecial;
-  tagint **special;
-  int *num_bond;
-  int **bond_type;
-  tagint **bond_atom;
-  int *num_angle;
-  int **angle_type;
-  tagint **angle_atom1,**angle_atom2,**angle_atom3;
-  int *num_dihedral;
-  int **dihedral_type;
-  tagint **dihedral_atom1,**dihedral_atom2,**dihedral_atom3,**dihedral_atom4;
-  int *num_improper;
-  int **improper_type;
-  tagint **improper_atom1,**improper_atom2,**improper_atom3,**improper_atom4;
+
+  int any_bond_negative, any_angle_negative, any_dihedral_negative, any_improper_negative;
+  int bond_per_atom, angle_per_atom, dihedral_per_atom, improper_per_atom;
+  int *bond_negative, *angle_negative, *dihedral_negative, *improper_negative;
 };
 
-}
+}    // namespace LAMMPS_NS
 
 #endif
 #endif
-
-/* ERROR/WARNING messages:
-
-E: Per-processor system is too big
-
-The number of owned atoms plus ghost atoms on a single
-processor must fit in 32-bit integer.
-
-E: Invalid atom type in Atoms section of data file
-
-Atom types must range from 1 to specified # of types.
-
-*/

--- a/src/compute_contactmap.cpp
+++ b/src/compute_contactmap.cpp
@@ -78,7 +78,7 @@ ComputeContactmap::~ComputeContactmap()
 
 void ComputeContactmap::init()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Compute contactmap requires atom style awsemmd");
 
   // check to make sure tags are enabled
@@ -103,7 +103,7 @@ double ComputeContactmap::compute_scalar()
   double **x = atom->x; // atom positions
   int *mask = atom->mask; // atom mask (?)
   int *tag = atom->tag; // atom index
-  int *residue = avec->residue; // atom's residue index
+  int *residue = atom->residue; // atom's residue index
   int nlocal = atom->nlocal; // number of atoms on this processor
   int nall = atom->nlocal + atom->nghost; // total number of atoms
   

--- a/src/compute_contactmap.h
+++ b/src/compute_contactmap.h
@@ -7,9 +7,9 @@
    ------------------------------------------------------------------------- */
 
 #ifdef COMPUTE_CLASS
-
+// clang-format off
 ComputeStyle(contactmap,ComputeContactmap)
-
+// clang-format on
 #else
 
 #ifndef LMP_COMPUTE_CONTACTMAP_H

--- a/src/compute_pairdistmat.cpp
+++ b/src/compute_pairdistmat.cpp
@@ -70,7 +70,7 @@ ComputePairdistmat::~ComputePairdistmat()
 
 void ComputePairdistmat::init()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Compute pairdistmat requires atom style awsemmd");
 
   // check to make sure tags are enabled
@@ -95,7 +95,7 @@ double ComputePairdistmat::compute_scalar()
   double **x = atom->x; // atom positions
   int *mask = atom->mask; // atom mask (?)
   int *tag = atom->tag; // atom index
-  int *residue = avec->residue; // atom's residue index
+  int *residue = atom->residue; // atom's residue index
   int nlocal = atom->nlocal; // number of atoms on this processor
   int nall = atom->nlocal + atom->nghost; // total number of atoms
   

--- a/src/compute_pairdistmat.h
+++ b/src/compute_pairdistmat.h
@@ -7,9 +7,9 @@
    ------------------------------------------------------------------------- */
 
 #ifdef COMPUTE_CLASS
-
+// clang-format off
 ComputeStyle(pairdistmat,ComputePairdistmat)
-
+// clang-format on
 #else
 
 #ifndef LMP_COMPUTE_PAIRDISTMAT_H

--- a/src/compute_q_onuchic.cpp
+++ b/src/compute_q_onuchic.cpp
@@ -137,7 +137,7 @@ ComputeQOnuchic::~ComputeQOnuchic()
 
 void ComputeQOnuchic::init()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Compute qonuchic requires atom style awsemmd");
 
   if (atom->tag_enable == 0)
@@ -235,7 +235,7 @@ double ComputeQOnuchic::compute_scalar()
   int *mask = atom->mask;
   int *type = atom->type;
   int *tag = atom->tag;
-  int *res = avec->residue;
+  int *res = atom->residue;
   int *image = atom->image;
   int nlocal = atom->nlocal;
   int nall = atom->nlocal + atom->nghost;

--- a/src/compute_q_onuchic.h
+++ b/src/compute_q_onuchic.h
@@ -9,9 +9,9 @@ Last Update: 08/18/2011
 ------------------------------------------------------------------------- */
 
 #ifdef COMPUTE_CLASS
-
+// clang-format off
 ComputeStyle(qonuchic,ComputeQOnuchic)
-
+// clang-format on
 #else
 
 #ifndef LMP_COMPUTE_QONUCHIC_H

--- a/src/compute_q_wolynes.cpp
+++ b/src/compute_q_wolynes.cpp
@@ -120,7 +120,7 @@ ComputeQWolynes::~ComputeQWolynes()
 
 void ComputeQWolynes::init()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Compute qwolynes requires atom style awsemmd");
 
   // check to make sure tags are enabled
@@ -164,7 +164,7 @@ double ComputeQWolynes::compute_scalar()
   int *mask = atom->mask; // atom mask (?)
   int *image = atom->image; // atom image
   int *tag = atom->tag; // atom index
-  int *residue = avec->residue; // atom's residue index
+  int *residue = atom->residue; // atom's residue index
   int nlocal = atom->nlocal; // number of atoms on this processor
   int nall = atom->nlocal + atom->nghost; // total number of atoms
   

--- a/src/compute_q_wolynes.h
+++ b/src/compute_q_wolynes.h
@@ -7,9 +7,9 @@
    ------------------------------------------------------------------------- */
 
 #ifdef COMPUTE_CLASS
-
+// clang-format off
 ComputeStyle(qwolynes,ComputeQWolynes)
-
+// clang-format on
 #else
 
 #ifndef LMP_COMPUTE_QWOLYNES_H

--- a/src/compute_totalcontacts.cpp
+++ b/src/compute_totalcontacts.cpp
@@ -79,7 +79,7 @@ ComputeTotalcontacts::~ComputeTotalcontacts()
 
 void ComputeTotalcontacts::init()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Compute totalcontacts requires atom style awsemmd");
 
   // check to make sure tags are enabled
@@ -101,7 +101,7 @@ double ComputeTotalcontacts::compute_scalar()
   double **x = atom->x; // atom positions
   int *mask = atom->mask; // atom mask (?)
   int *tag = atom->tag; // atom index
-  int *residue = avec->residue; // atom's residue index
+  int *residue = atom->residue; // atom's residue index
   int nlocal = atom->nlocal; // number of atoms on this processor
   int nall = atom->nlocal + atom->nghost; // total number of atoms
   

--- a/src/compute_totalcontacts.h
+++ b/src/compute_totalcontacts.h
@@ -7,9 +7,9 @@
    ------------------------------------------------------------------------- */
 
 #ifdef COMPUTE_CLASS
-
+// clang-format off
 ComputeStyle(totalcontacts,ComputeTotalcontacts)
-
+// clang-format on
 #else
 
 #ifndef LMP_COMPUTE_TOTALCONTACTS_H

--- a/src/fix_backbone.h
+++ b/src/fix_backbone.h
@@ -12,9 +12,9 @@ Last Update: 12/20/2017
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
-
+// clang-format off
 FixStyle(backbone,FixBackbone)
-
+// clang-format on
 #else
 
 #ifndef LMP_FIX_BACKBONE_H

--- a/src/fix_go-model.h
+++ b/src/fix_go-model.h
@@ -9,7 +9,9 @@ Gaussian Contacts Potential was contributed by Weihua Zheng
 Last Update: 03/23/2011
 ------------------------------------------------------------------------- */
 #ifdef FIX_CLASS
+// clang-format off
 FixStyle(gomodel, FixGoModel)
+// clang-format on
 #else
 
 #ifndef FIX_GOMODEL_H
@@ -98,7 +100,7 @@ private:
   inline double PeriodicityCorrection(double d, int i);
   inline bool isFirst(int index);
   inline bool isLast(int index);
-  inline void print_log(char *line);
+  inline void print_log(const char *line);
 
   int Step;
   int sStep, eStep;

--- a/src/fix_print_wzero.cpp
+++ b/src/fix_print_wzero.cpp
@@ -61,10 +61,8 @@ FixPrintWithZero::FixPrintWithZero(LAMMPS *lmp, int narg, char **arg) :
       if (me == 0) {
         if (strcmp(arg[iarg],"file") == 0) fp = fopen(arg[iarg+1],"w");
         else fp = fopen(arg[iarg+1],"a");
-        if (fp == NULL) {
-          char str[128];
-          sprintf(str,"Cannot open fix print/wzero file %s",arg[iarg+1]);
-          error->one(FLERR,str);
+        if (fp == nullptr) {
+          error->one(FLERR, "Cannot open fix print/wzero file {}: {}", arg[iarg+1], utils::getsyserror());
         }
       }
       iarg += 2;

--- a/src/fix_print_wzero.h
+++ b/src/fix_print_wzero.h
@@ -16,9 +16,9 @@
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
-
+// clang-format off
 FixStyle(print/wzero,FixPrintWithZero)
-
+// clang-format on
 #else
 
 #ifndef LMP_FIX_PRINT_WZERO_H

--- a/src/fix_qbias.h
+++ b/src/fix_qbias.h
@@ -8,9 +8,9 @@ Last Update: 12/01/2010
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
-
+// clang-format off
 FixStyle(qbias,FixQBias)
-
+// clang-format on
 #else
 
 #ifndef LMP_FIX_QBIAS_H
@@ -77,7 +77,7 @@ private:
   inline double PeriodicityCorrection(double d, int i);
   inline bool isFirst(int index);
   inline bool isLast(int index);
-  inline void print_log(char *line);
+  inline void print_log(const char *line);
 
   int Step;
   int sStep, eStep;

--- a/src/fix_spring_rg_papoian.cpp
+++ b/src/fix_spring_rg_papoian.cpp
@@ -96,8 +96,8 @@ void FixSpringRGPapoian::init()
     rg0_flag = 0;
   }
 
-  if (strstr(update->integrate_style,"respa")) {
-    ilevel_respa = ((Respa *) update->integrate)->nlevels-1;
+  if (utils::strmatch(update->integrate_style,"^respa")) {
+    ilevel_respa = (dynamic_cast<Respa *>( update->integrate))->nlevels-1;
     if (respa_level >= 0) ilevel_respa = MIN(respa_level,ilevel_respa);
   }
 }
@@ -106,12 +106,12 @@ void FixSpringRGPapoian::init()
 
 void FixSpringRGPapoian::setup(int vflag)
 {
-  if (strstr(update->integrate_style,"verlet"))
+  if (utils::strmatch(update->integrate_style,"^verlet"))
     post_force(vflag);
   else {
-    ((Respa *) update->integrate)->copy_flevel_f(ilevel_respa);
+    (dynamic_cast<Respa *>( update->integrate))->copy_flevel_f(ilevel_respa);
     post_force_respa(vflag,ilevel_respa,0);
-    ((Respa *) update->integrate)->copy_f_flevel(ilevel_respa);
+    (dynamic_cast<Respa *>( update->integrate))->copy_f_flevel(ilevel_respa);
   }
 }
 

--- a/src/fix_spring_rg_papoian.h
+++ b/src/fix_spring_rg_papoian.h
@@ -28,9 +28,9 @@
  -------------------------------------------------------------------------*/
 
 #ifdef FIX_CLASS
-
+// clang-format off
 FixStyle(spring/rg/papoian,FixSpringRGPapoian)
-
+// clang-format on
 #else
 
 #ifndef LMP_FIX_SPRING_RG_PAPOIAN_H

--- a/src/pair_ex_gauss_coul_cut.cpp
+++ b/src/pair_ex_gauss_coul_cut.cpp
@@ -451,7 +451,7 @@ void PairExGaussCoulCut::init_style()
   if (!atom->q_flag)
     error->all(FLERR,"Pair style ex/gauss/coul/cut requires atom attribute q");
 
-  neighbor->request(this,instance_me);
+  neighbor->add_request(this, NeighConst::REQ_DEFAULT);
 
   el_flag = false;
 }

--- a/src/pair_ex_gauss_coul_cut.h
+++ b/src/pair_ex_gauss_coul_cut.h
@@ -10,9 +10,9 @@ Last Update: 05/01/2012
 ------------------------------------------------------------------------- */
 
 #ifdef PAIR_CLASS
-
+// clang-format off
 PairStyle(ex/gauss/coul/cut,PairExGaussCoulCut)
-
+// clang-format on
 #else
 
 #ifndef LMP_PAIR_EX_GAUSS_COUL_CUT_H

--- a/src/pair_excluded_volume.cpp
+++ b/src/pair_excluded_volume.cpp
@@ -98,8 +98,8 @@ void PairExcludedVolume::compute(int eflag, int vflag)
       imol = atom->molecule[i];
       jmol = atom->molecule[j];
       
-      ires = avec->residue[i];
-      jres = avec->residue[j];
+      ires = atom->residue[i];
+      jres = atom->residue[j];
 
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
@@ -238,10 +238,10 @@ void PairExcludedVolume::coeff(int narg, char **arg)
 
 void PairExcludedVolume::init_style()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM *> (atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Pair excluded_volume requires atom style awsemmd");
 
-  neighbor->request(this,instance_me);
+  neighbor->add_request(this, NeighConst::REQ_DEFAULT);
 }
 
 /* ----------------------------------------------------------------------
@@ -356,8 +356,8 @@ double PairExcludedVolume::single(int i, int j, int itype, int jtype, double rsq
   imol = atom->molecule[i];
   jmol = atom->molecule[j];
   
-  ires = avec->residue[i];
-  jres = avec->residue[j];
+  ires = atom->residue[i];
+  jres = atom->residue[j];
 
   if (abs(ires-jres)<5 && imol==jmol) rcut = cut_short[itype][jtype];
   else rcut = cut_long[itype][jtype];

--- a/src/pair_excluded_volume.h
+++ b/src/pair_excluded_volume.h
@@ -8,9 +8,9 @@ Last Update: 12/01/2010
 ------------------------------------------------------------------------- */
 
 #ifdef PAIR_CLASS
-
+// clang-format off
 PairStyle(vexcluded,PairExcludedVolume)
-
+// clang-format on
 #else
 
 #ifndef LMP_PAIR_EXCLUDED_VOLUME_H

--- a/src/pair_go-contacts.cpp
+++ b/src/pair_go-contacts.cpp
@@ -41,7 +41,7 @@ PairGoContacts::PairGoContacts(LAMMPS *lmp) : Pair(lmp)
 
 /* ---------------------------------------------------------------------- */
 
-inline void PairGoContacts::print_log(char *line)
+inline void PairGoContacts::print_log(const char *line)
 {
   if (screen) fprintf(screen, line);
   if (logfile) fprintf(logfile, line);
@@ -140,8 +140,8 @@ void PairGoContacts::compute(int eflag, int vflag)
       imol = atom->molecule[i]-1;
       jmol = atom->molecule[j]-1;
       
-      ires = avec->residue[i]-1;
-      jres = avec->residue[j]-1;
+      ires = atom->residue[i]-1;
+      jres = atom->residue[j]-1;
       
       if (abs(jres-ires)<=3) continue;
 
@@ -370,10 +370,10 @@ void PairGoContacts::coeff(int narg, char **arg)
 
 void PairGoContacts::init_style()
 {
-  avec = (AtomVecAWSEM *) atom->style_match("awsemmd");
+  avec = dynamic_cast<AtomVecAWSEM*>(atom->style_match("awsemmd"));
   if (!avec) error->all(FLERR,"Pair go-contacts requires atom style awsemmd");
 
-  neighbor->request(this,instance_me);
+  neighbor->add_request(this, NeighConst::REQ_DEFAULT);
 }
 
 /* ----------------------------------------------------------------------
@@ -524,8 +524,8 @@ double PairGoContacts::single(int i, int j, int itype, int jtype, double rsq,
   imol = atom->molecule[i]-1;
   jmol = atom->molecule[j]-1;
   
-  ires = avec->residue[i]-1;
-  jres = avec->residue[j]-1;
+  ires = atom->residue[i]-1;
+  jres = atom->residue[j]-1;
   
 // || rsq>sigma_sq[ires][jres]*9
   if (abs(jres-ires)<=3 || rsq>=cutsq[itype][jtype] || rsq>sigma_sq[ires][jres]*9) return 0.0;

--- a/src/pair_go-contacts.h
+++ b/src/pair_go-contacts.h
@@ -8,9 +8,9 @@ Last Update: 12/01/2010
 ------------------------------------------------------------------------- */
 
 #ifdef PAIR_CLASS
-
+// clang-format off
 PairStyle(gocontacts,PairGoContacts)
-
+// clang-format on
 #else
 
 #ifndef LMP_PAIR_GO_CONTACTS_H
@@ -59,7 +59,7 @@ class PairGoContacts : public Pair {
   
   enum ContactsDevType{DT_NONE=0, DT_CORR, DT_SIN, DT_CONST};
   
-  inline void print_log(char *line);
+  inline void print_log(const char *line);
   void compute_contact_deviation();
 
   void allocate();


### PR DESCRIPTION
This update builds from the [stable_29Oct2020](https://github.com/adavtyan/awsemmd/releases/tag/stable_29Oct2020_updated) update to AWSEMMD, and is intended to function on [LAMMPS stable_23Jun2022](https://github.com/lammps/lammps/releases/tag/stable_23Jun2022).

Included below is a brief overview of changes:

- 2022 derived atom.cpp and atom.h files are included with the residue variable built in. These are included to maintain the backward compatability to the previous method of install of copying AWSEMMD/src/ files to LAMMPS/src/ and compiling as usual. 
- updated syntax using the [LAMMPS changelog](https://docs.lammps.org/Developer_updating.html), including:
   - Neighbour list requests
   - Respa related syntax
   - Simplify customized error message

- Some simple to fix compiler warnings are addressed, such as:
   - warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
   - warning: control reaches end of non-void function [-Wreturn-type]
   - warning: converting to non-pointer type 'double' from NULL [-Wconversion-null]
   
In addressing the last listed compiler warning, I opted on removing the `atan2` declaration shipped with code, and allow this instead to be inherited from `<cmath>`. This way it addresses the compiler warning, is more robust to various data types and is more standardised with other LAMMPS packages.

These changes have been tested for compilation, running and some thermodynamics by myself using the existing examples on three different architectures, from which all seems fine.

Feel free to get in touch with comments, suggestions or for more information.